### PR TITLE
Add AspectHolder, Id, and Sheet structure

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,16 +7,22 @@
       "devDependencies": {
         "@eslint/js": "^10.0.1",
         "@types/bun": "latest",
-        "eslint": "^10.1.0",
-        "prettier": "^3.8.1",
-        "typescript-eslint": "^8.57.2",
+        "eslint": "^10.4.0",
+        "prettier": "^3.8.3",
+        "typescript-eslint": "^8.60.0",
       },
       "peerDependencies": {
-        "typescript": "^5",
+        "typescript": "^5.9.3",
       },
     },
     "packages/core": {
       "name": "@atelier/core",
+    },
+    "packages/playground": {
+      "name": "@atelier/playground",
+      "dependencies": {
+        "@atelier/core": "workspace:*",
+      },
     },
     "packages/server": {
       "name": "@atelier/server",
@@ -27,6 +33,8 @@
   },
   "packages": {
     "@atelier/core": ["@atelier/core@workspace:packages/core"],
+
+    "@atelier/playground": ["@atelier/playground@workspace:packages/playground"],
 
     "@atelier/server": ["@atelier/server@workspace:packages/server"],
 

--- a/docs/CORE.md
+++ b/docs/CORE.md
@@ -61,13 +61,70 @@ that role demands. Structure accretes; it is not mandated up front.
 
 ---
 
+## Structure
+
+A factory that creates a `Composite` subclass with aspects pre-initialized. The canonical
+way to define an entity type.
+
+```ts
+const Sheet = Structure(
+  [Id,     () => new Id()],
+  [Holder, () => new AspectHolder()],
+);
+
+const sheet = new Sheet(); // Id and Holder already provided
+```
+
+Each entry is `[AspectRef, () => T]`. The thunk is called once per constructor invocation,
+so every instance gets its own fresh aspect values — no shared state.
+
+`Structure` imposes no required aspects and performs no validation. It is purely a
+convenience over calling `provide` manually in a subclass constructor. Validation (once
+needed) lives in a separate Template or StructureAspect, not inside `Structure` itself.
+
+---
+
+## Holder
+
+Intra-entity child discovery. A composite that has children exposes a `Holder` aspect;
+anything that needs to iterate those children calls `sheet.get(Holder).children(sheet)`.
+
+```ts
+interface Holder<T extends Composite = Composite> {
+  children(parent: T): Iterable<Composite>;
+}
+
+const Holder = new AspectKey<Holder<Composite>>("Holder");
+```
+
+The generic `T` lets an implementation access the parent's typed aspects without casts.
+`Holder<Composite>` is used at the key level as the base contract; method bivariance allows
+more-specific implementations (`Holder<Sheet>`, `Holder<Monster>`) to be stored under it.
+
+**`AspectHolder<T>`** is the built-in implementation. It yields every aspect value of the
+parent that is itself a `Composite`:
+
+```ts
+class AspectHolder<T extends Composite = Composite> implements Holder<T> {
+  *children(parent: T): Iterable<Composite> {
+    for (const value of parent.aspects.values())
+      if (value instanceof Composite) yield value;
+  }
+}
+```
+
+`AspectHolder` is the default for `Sheet`. Custom holders can filter, reorder, or aggregate
+differently — the consumer (e.g. `AbilityScore.refresh`) is decoupled from the strategy.
+
+---
+
 ## Capability discovery
 
 The reusable discovery primitive is **filter a collection by capability**. It runs over a
-composite's aspect values (intra-entity: a sheet's stat contributors) and over a scope's
-composites (inter-entity: "find all sheets in the scene with a resist effect") with the
-same shape. This is the single pattern reused across mechanics — feats that modify anything
-on a sheet, environmental effects that query all sheets, etc.
+composite's children via `Holder` (intra-entity: a sheet's stat contributors) and over a
+scope's composites (inter-entity: "find all sheets in the scene with a resist effect") with
+the same shape. This is the single pattern reused across mechanics — feats that modify
+anything on a sheet, environmental effects that query all sheets, etc.
 
 Discovery is **dynamic and rebuilt on demand**, not maintained as a synced list. Because all
 SRD content is treated as homebrew (homebrew is an extension of the base engine, not a
@@ -124,7 +181,7 @@ This is what makes prefabs reusable without ID collisions.
 ## Template / StructureAspect
 
 Declares the aspects an entity type is expected to have. Used for validation and "what is
-this?" identification.
+this?" identification. `Template.validate(composite)` throws listing all missing aspects.
 
 The long-term direction is a **StructureAspect**: structure becomes an aspect carried by the
 composite (kind = item / trait / monster / prop / sheet, plus the expected aspect set) rather
@@ -134,7 +191,7 @@ the "missing aspect = content bug = throw" stance.
 
 StructureAspect is **derived, not declared twice**: the serializer generates the necessary
 structural information from the `@Property` declarations rather than the author maintaining a
-separate schema. (Not built yet — realized when complexity demands it.)
+separate schema. (Not built yet — merged into `Structure` when complexity demands it.)
 
 ---
 
@@ -181,8 +238,8 @@ advanced, chat).
 
 Computed stats (ability scores, and later AC, saves, skills) are a **pure projection** over
 a set of contributors. Anything that writes to a stat exposes the contributor capability and
-is discovered by capability query over the owning composite's values; the computed stat
-aspect rebuilds itself by gathering and folding those contributions.
+is discovered by capability query over the owning composite's children (via `Holder`); the
+computed stat aspect rebuilds itself by gathering and folding those contributions.
 
 Key commitments (these are the content-facing contract — expensive to change because every
 piece of content is written against them):

--- a/docs/ENV.md
+++ b/docs/ENV.md
@@ -11,9 +11,10 @@ imports/aliases._
 packages/
 ├── core/        # shared types, primitives, base classes — no Bun APIs, no Svelte
 ├── server/      # Hono server, game engine, SRD content, CLI
-└── client/      # SvelteKit frontend
+├── client/      # SvelteKit frontend (not yet created)
+└── playground/  # scratch pad for manual testing of core primitives
 
-content/         # user-defined homebrew (explicit index.ts entry point)
+content/         # user-defined homebrew (not yet created; explicit index.ts entry point)
 CLAUDE.md        # router + invariants
 ```
 
@@ -24,9 +25,9 @@ CLAUDE.md        # router + invariants
 All imports use package aliases. **Never use relative paths that cross package boundaries.**
 
 ```ts
-import { Aspect } from "@atelier/core/composite/Aspect";
+import { Composite } from "@atelier/core/composite/Composite";
 import { Subscribe } from "@atelier/core/event/Event";
-import { AbilityScoresAspect } from "@atelier/server/aspects/AbilityScores";
+import { SomeServerThing } from "@atelier/server/path/to/module";
 ```
 
 `@atelier/core/*` for core primitives. `@atelier/server/*` for server internals.
@@ -77,14 +78,14 @@ Content files use both — never `../../packages/`.
       "@atelier/server/*": ["./src/*"]
     }
   },
-  "include": ["src", "../../content"]
+  "include": ["src"]
 }
 ```
 
-Note `content` is included here — this gives content files type-checking and alias
-resolution without any extra config on the content author's side.
+When the `content/` directory is added, extend `include` to `["src", "../../content"]` so
+content files get type-checking and alias resolution without extra config.
 
-### `packages/client/tsconfig.json`
+### `packages/client/tsconfig.json` (planned)
 
 ```json
 {
@@ -98,7 +99,7 @@ resolution without any extra config on the content author's side.
 }
 ```
 
-### `content/tsconfig.json`
+### `content/tsconfig.json` (planned)
 
 ```json
 {
@@ -127,15 +128,22 @@ aliases automatically. Content authors never touch tsconfig.
 ```json
 {
   "name": "@atelier/core",
-  "module": "src/index.ts"
+  "module": "src/index.ts",
+  "type": "module",
+  "exports": { "./*": "./src/*" }
 }
 ```
+
+The `exports` map is what resolves `@atelier/core/composite/Composite` to
+`./src/composite/Composite.ts` at runtime.
 
 ### `packages/server/package.json`
 
 ```json
 {
   "name": "@atelier/server",
+  "module": "src/index.ts",
+  "type": "module",
   "dependencies": {
     "@atelier/core": "workspace:*"
   }

--- a/docs/ENV.md
+++ b/docs/ENV.md
@@ -87,6 +87,10 @@ content files get type-checking and alias resolution without extra config.
 
 ### `packages/client/tsconfig.json` (planned)
 
+`packages/client` will be the SvelteKit frontend. It needs `$lib/*` (SvelteKit's built-in
+alias for `src/lib`) and `@atelier/core/*` for shared types. No `@atelier/server` alias —
+the client never imports server internals directly.
+
 ```json
 {
   "extends": "../../tsconfig.json",
@@ -101,14 +105,15 @@ content files get type-checking and alias resolution without extra config.
 
 ### `content/tsconfig.json` (planned)
 
+`content/` will hold user-defined homebrew — classes, races, spells, items. It extends the
+server tsconfig so content files automatically get both `@atelier/core` and `@atelier/server`
+aliases. Content authors never touch tsconfig.
+
 ```json
 {
   "extends": "../packages/server/tsconfig.json"
 }
 ```
-
-Extends server tsconfig so content files get `@atelier/core` and `@atelier/server`
-aliases automatically. Content authors never touch tsconfig.
 
 ---
 
@@ -134,8 +139,10 @@ aliases automatically. Content authors never touch tsconfig.
 }
 ```
 
-The `exports` map is what resolves `@atelier/core/composite/Composite` to
-`./src/composite/Composite.ts` at runtime.
+The `exports` map is what resolves subpath imports like `@atelier/core/composite/Composite`
+to `./src/composite/Composite.ts`. The `module` field is a bundler convention (Bun, Rollup,
+Vite) for the ESM entry point used when the package is imported without a subpath
+(`import "@atelier/core"`); it does not affect subpath imports.
 
 ### `packages/server/package.json`
 

--- a/packages/core/src/composite/AspectHolder.ts
+++ b/packages/core/src/composite/AspectHolder.ts
@@ -1,0 +1,10 @@
+import { Composite } from "./Composite";
+import { type Holder } from "./Structure";
+
+export class AspectHolder<T extends Composite = Composite> implements Holder<T> {
+  *children(parent: T): Iterable<Composite> {
+    for (const value of parent.aspects.values()) {
+      if (value instanceof Composite) yield value as Composite;
+    }
+  }
+}

--- a/packages/core/src/composite/Id.ts
+++ b/packages/core/src/composite/Id.ts
@@ -1,0 +1,8 @@
+import { Aspect } from "./Composite";
+import { Property } from "../serial/Data";
+
+@Aspect("Id")
+export class Id {
+  @Property.Primitive
+  value: string = crypto.randomUUID();
+}

--- a/packages/core/src/composite/Structure.ts
+++ b/packages/core/src/composite/Structure.ts
@@ -11,8 +11,8 @@ export function Structure<const Types extends readonly object[]>(
   };
 }
 
-interface Holder<T> {
-  children(parent: T): Generator<Iterable<Composite>>;
+export interface Holder<T extends Composite = Composite> {
+  children(parent: T): Iterable<Composite>;
 }
 
-export const Holder = new AspectKey<Holder<any>>("Holder");
+export const Holder = new AspectKey<Holder<Composite>>("Holder");

--- a/packages/core/src/dnd/Sheet.test.ts
+++ b/packages/core/src/dnd/Sheet.test.ts
@@ -1,5 +1,4 @@
 import { expect, test } from "bun:test";
-import { Composite } from "../composite/Composite";
 import { AbilityScore } from "../stats/AbilityScore";
 import {
   PointBuyScore,
@@ -7,17 +6,32 @@ import {
   BaseAbilityScore,
   POINT_BUY_BUDGET,
 } from "../stats/BaseAbilityScore";
-import { SheetTemplate } from "./Sheet";
+import { Holder } from "../composite/Structure";
+import { Id } from "../composite/Id";
+import { Sheet } from "./Sheet";
 
-test("validate passes with point buy scores", () => {
-  const sheet = new Composite();
-  sheet.provide(BaseAbilityScore, new PointBuyScore());
-  sheet.provide(AbilityScore, new AbilityScore());
-  expect(() => SheetTemplate.validate(sheet)).not.toThrow();
+test("sheet provides Id", () => {
+  const sheet = new Sheet();
+  expect(sheet.has(Id)).toBe(true);
+  expect(typeof sheet.get(Id).value).toBe("string");
 });
 
-test("validate passes with static scores", () => {
-  const sheet = new Composite();
+test("sheet provides Holder", () => {
+  const sheet = new Sheet();
+  expect(sheet.has(Holder)).toBe(true);
+});
+
+test("refresh via Holder applies point buy contributions", () => {
+  const sheet = new Sheet();
+  sheet.provide(BaseAbilityScore, new PointBuyScore());
+  const score = new AbilityScore();
+  sheet.provide(AbilityScore, score);
+  score.refresh(sheet);
+  expect(score.scores.strength).toBe(8);
+});
+
+test("refresh via Holder applies static contributions", () => {
+  const sheet = new Sheet();
   sheet.provide(
     BaseAbilityScore,
     new StaticAbilityScore({
@@ -29,20 +43,11 @@ test("validate passes with static scores", () => {
       charisma: 8,
     }),
   );
-  sheet.provide(AbilityScore, new AbilityScore());
-  expect(() => SheetTemplate.validate(sheet)).not.toThrow();
-});
-
-test("validate throws without base ability scores", () => {
-  const sheet = new Composite();
-  sheet.provide(AbilityScore, new AbilityScore());
-  expect(() => SheetTemplate.validate(sheet)).toThrow();
-});
-
-test("validate throws without ability scores", () => {
-  const sheet = new Composite();
-  sheet.provide(BaseAbilityScore, new PointBuyScore());
-  expect(() => SheetTemplate.validate(sheet)).toThrow();
+  const score = new AbilityScore();
+  sheet.provide(AbilityScore, score);
+  score.refresh(sheet);
+  expect(score.scores.strength).toBe(15);
+  expect(score.scores.charisma).toBe(8);
 });
 
 test("default base scores cost zero points", () => {

--- a/packages/core/src/dnd/Sheet.ts
+++ b/packages/core/src/dnd/Sheet.ts
@@ -1,5 +1,8 @@
-import { Template } from "../composite/Composite";
-import { AbilityScore } from "../stats/AbilityScore";
-import { BaseAbilityScore } from "../stats/BaseAbilityScore";
+import { Structure, Holder } from "../composite/Structure";
+import { Id } from "../composite/Id";
+import { AspectHolder } from "../composite/AspectHolder";
 
-export const SheetTemplate = new Template("Sheet", [BaseAbilityScore, AbilityScore]);
+export const Sheet = Structure(
+  [Id, () => new Id()],
+  [Holder, () => new AspectHolder()],
+);

--- a/packages/core/src/dnd/Sheet.ts
+++ b/packages/core/src/dnd/Sheet.ts
@@ -2,7 +2,4 @@ import { Structure, Holder } from "../composite/Structure";
 import { Id } from "../composite/Id";
 import { AspectHolder } from "../composite/AspectHolder";
 
-export const Sheet = Structure(
-  [Id, () => new Id()],
-  [Holder, () => new AspectHolder()],
-);
+export const Sheet = Structure([Id, () => new Id()], [Holder, () => new AspectHolder()]);

--- a/packages/core/src/stats/AbilityScore.ts
+++ b/packages/core/src/stats/AbilityScore.ts
@@ -1,4 +1,5 @@
 import { Aspect, AspectKey, Composite } from "../composite/Composite";
+import { Holder } from "../composite/Structure";
 import { enumMap } from "../util/Types";
 
 export const Abilities = [
@@ -25,9 +26,9 @@ export class AbilityScore {
   scores: Record<Ability, number> = enumMap(Abilities, (_) => 0);
 
   refresh(sheet: Composite): void {
-    for (const v of sheet.aspects.values()) {
-      if (v instanceof Composite && v.has(AbilityScoreContributor)) {
-        v.get(AbilityScoreContributor).apply(this);
+    for (const child of sheet.get(Holder).children(sheet)) {
+      if (child.has(AbilityScoreContributor)) {
+        child.get(AbilityScoreContributor).apply(this);
       }
     }
   }

--- a/packages/playground/src/Main.ts
+++ b/packages/playground/src/Main.ts
@@ -1,14 +1,9 @@
-import { Structure } from "@atelier/core/composite/Structure";
+import { Sheet } from "@atelier/core/dnd/Sheet";
+import { Id } from "@atelier/core/composite/Id";
 import { AbilityScore } from "@atelier/core/stats/AbilityScore";
 import { BaseAbilityScore, PointBuyScore } from "@atelier/core/stats/BaseAbilityScore";
 
-class Id {
-  readonly value = crypto.randomUUID();
-}
-
-const Entity = Structure([Id, () => new Id()]);
-
-const sheet = new Entity();
+const sheet = new Sheet();
 const score = new AbilityScore();
 sheet.provide(BaseAbilityScore, new PointBuyScore());
 sheet.provide(AbilityScore, score);


### PR DESCRIPTION
- Fix Holder<T> interface: export it, change return type to Iterable<Composite>, tighten AspectKey from Holder<any> to Holder<Composite>, add default type param
- Add Id aspect with serializable UUID value
- Add AspectHolder<T extends Composite> implementing Holder<T> by yielding composite-valued aspects
- Replace SheetTemplate in Sheet.ts with a Structure-based Sheet (Id + Holder backed by AspectHolder)

https://claude.ai/code/session_01KWSaSg7GqWMUgi1LP1F6rj