### PR TITLE
Fold Template into Structure; declare BaseAbilityScore as expected on Sheet

### DIFF
--- a/docs/CORE.md
+++ b/docs/CORE.md
@@ -67,10 +67,7 @@ A factory that creates a `Composite` subclass with aspects pre-initialized. The 
 way to define an entity type.
 
 ```ts
-const Sheet = Structure(
-  [Id,     () => new Id()],
-  [Holder, () => new AspectHolder()],
-);
+const Sheet = Structure([Id, () => new Id()], [Holder, () => new AspectHolder()]);
 
 const sheet = new Sheet(); // Id and Holder already provided
 ```
@@ -107,8 +104,7 @@ parent that is itself a `Composite`:
 ```ts
 class AspectHolder<T extends Composite = Composite> implements Holder<T> {
   *children(parent: T): Iterable<Composite> {
-    for (const value of parent.aspects.values())
-      if (value instanceof Composite) yield value;
+    for (const value of parent.aspects.values()) if (value instanceof Composite) yield value;
   }
 }
 ```

--- a/packages/core/src/composite/Composite.ts
+++ b/packages/core/src/composite/Composite.ts
@@ -1,4 +1,5 @@
 import { Constructor } from "../util/Types";
+import { BiMap } from "../util/Algorithms";
 
 // Aspects
 
@@ -14,11 +15,33 @@ export class AspectKey<T> {
 }
 
 const aspectRegistry = new WeakMap<Constructor, AspectKey<unknown>>();
+const aspectTypeMaps = new Map<symbol, BiMap<string, Constructor>>();
 
-export function Aspect(id: string) {
+export function Aspect<T extends object>(id: string, key?: AspectKey<T>) {
   return (ctor: Constructor) => {
-    aspectRegistry.set(ctor, new AspectKey(id));
+    if (key) {
+      const map = getAspectTypeMap(key);
+      if (!map.set(id, ctor as Constructor<T>)) {
+        throw new Error(
+          `Aspect impl "${id}" already registered under "${key.name}" ` +
+            `(or constructor ${ctor.name} already mapped under that key)`,
+        );
+      }
+    } else {
+      aspectRegistry.set(ctor, new AspectKey(id));
+    }
   };
+}
+
+export function getAspectTypeMap<T extends object>(
+  key: AspectKey<T>,
+): BiMap<string, Constructor<T>> {
+  let map = aspectTypeMaps.get(key.id);
+  if (!map) {
+    map = new BiMap<string, Constructor>();
+    aspectTypeMaps.set(key.id, map);
+  }
+  return map as BiMap<string, Constructor<T>>;
 }
 
 export type AspectRef<T extends object> = AspectKey<T> | Constructor<T>;

--- a/packages/core/src/composite/Composite.ts
+++ b/packages/core/src/composite/Composite.ts
@@ -7,6 +7,7 @@ export class AspectKey<T> {
   declare readonly _type: T;
   readonly id: symbol;
   readonly name: string;
+  readonly typeMap = new BiMap<string, Constructor<T>>();
 
   constructor(name: string) {
     this.name = name;
@@ -15,13 +16,11 @@ export class AspectKey<T> {
 }
 
 const aspectRegistry = new WeakMap<Constructor, AspectKey<unknown>>();
-const aspectTypeMaps = new Map<symbol, BiMap<string, Constructor>>();
 
 export function Aspect<T extends object>(id: string, key?: AspectKey<T>) {
   return (ctor: Constructor) => {
     if (key) {
-      const map = getAspectTypeMap(key);
-      if (!map.set(id, ctor as Constructor<T>)) {
+      if (!key.typeMap.set(id, ctor as Constructor<T>)) {
         throw new Error(
           `Aspect impl "${id}" already registered under "${key.name}" ` +
             `(or constructor ${ctor.name} already mapped under that key)`,
@@ -31,17 +30,6 @@ export function Aspect<T extends object>(id: string, key?: AspectKey<T>) {
       aspectRegistry.set(ctor, new AspectKey(id));
     }
   };
-}
-
-export function getAspectTypeMap<T extends object>(
-  key: AspectKey<T>,
-): BiMap<string, Constructor<T>> {
-  let map = aspectTypeMaps.get(key.id);
-  if (!map) {
-    map = new BiMap<string, Constructor>();
-    aspectTypeMaps.set(key.id, map);
-  }
-  return map as BiMap<string, Constructor<T>>;
 }
 
 export type AspectRef<T extends object> = AspectKey<T> | Constructor<T>;

--- a/packages/core/src/composite/Composite.ts
+++ b/packages/core/src/composite/Composite.ts
@@ -1,7 +1,17 @@
 import { Constructor } from "../util/Types";
 import { BiMap } from "../util/Algorithms";
+import {
+  Property,
+  serialize as serializeFields,
+  deserialize as deserializeFields,
+  type SerializedObject,
+  type SerializationStrategy,
+} from "../serial/Data";
 
 // Aspects
+
+const aspectKeyByName = new Map<string, AspectKey<unknown>>();
+const aspectKeyById = new Map<symbol, AspectKey<unknown>>();
 
 export class AspectKey<T> {
   declare readonly _type: T;
@@ -10,8 +20,13 @@ export class AspectKey<T> {
   readonly typeMap = new BiMap<string, Constructor<T>>();
 
   constructor(name: string) {
+    if (aspectKeyByName.has(name)) {
+      throw new Error(`AspectKey "${name}" already registered`);
+    }
     this.name = name;
     this.id = Symbol(name);
+    aspectKeyByName.set(name, this as AspectKey<unknown>);
+    aspectKeyById.set(this.id, this as AspectKey<unknown>);
   }
 }
 
@@ -43,9 +58,46 @@ export function getAspectKey<T extends object>(ref: AspectRef<T>) {
   return key as AspectKey<T>;
 }
 
+// Aspect-map strategy: encodes Composite.aspects as { [name]: { $type, ...fields } }
+
+const aspectsStrategy: SerializationStrategy<Map<symbol, unknown>> = {
+  serialize(source) {
+    const out: SerializedObject = {};
+    for (const [symId, value] of source) {
+      const key = aspectKeyById.get(symId);
+      if (!key || key.typeMap.size === 0) continue;
+      const v = value as object;
+      const tag = key.typeMap.getKey(v.constructor as Constructor);
+      if (!tag) {
+        throw new Error(
+          `Aspect "${key.name}" value of type ${v.constructor.name} ` +
+            `has no entry in its typeMap`,
+        );
+      }
+      out[key.name] = { $type: tag, ...serializeFields(v) };
+    }
+    return Object.keys(out).length === 0 ? undefined : out;
+  },
+  deserialize(source, current) {
+    const map = current ?? new Map<symbol, unknown>();
+    for (const [name, raw] of Object.entries(source as SerializedObject)) {
+      const key = aspectKeyByName.get(name);
+      if (!key) throw new Error(`Unknown aspect "${name}"`);
+      const r = raw as SerializedObject;
+      const ctor = key.typeMap.get(r.$type as string);
+      if (!ctor) {
+        throw new Error(`Unknown $type "${r.$type}" for aspect "${name}"`);
+      }
+      map.set(key.id, deserializeFields(r, ctor));
+    }
+    return map;
+  },
+};
+
 // Composite
 
 export class Composite {
+  @Property.Serialize(aspectsStrategy)
   readonly aspects = new Map<symbol, unknown>();
 
   provide<T extends object>(aspect: AspectRef<T>, value: T): void {

--- a/packages/core/src/composite/Composite.ts
+++ b/packages/core/src/composite/Composite.ts
@@ -17,7 +17,8 @@ export class AspectKey<T> {
   declare readonly _type: T;
   readonly id: symbol;
   readonly name: string;
-  readonly typeMap = new BiMap<string, Constructor<T>>();
+  ctor?: Constructor<T>;
+  typeMap?: BiMap<string, Constructor<T>>;
 
   constructor(name: string) {
     if (aspectKeyByName.has(name)) {
@@ -35,6 +36,7 @@ const aspectRegistry = new WeakMap<Constructor, AspectKey<unknown>>();
 export function Aspect<T extends object>(id: string, key?: AspectKey<T>) {
   return (ctor: Constructor) => {
     if (key) {
+      if (!key.typeMap) key.typeMap = new BiMap<string, Constructor<T>>();
       if (!key.typeMap.set(id, ctor as Constructor<T>)) {
         throw new Error(
           `Aspect impl "${id}" already registered under "${key.name}" ` +
@@ -43,7 +45,7 @@ export function Aspect<T extends object>(id: string, key?: AspectKey<T>) {
       }
     } else {
       const newKey = new AspectKey(id);
-      newKey.typeMap.set(id, ctor);
+      newKey.ctor = ctor;
       aspectRegistry.set(ctor, newKey);
     }
   };
@@ -65,16 +67,20 @@ const aspectsStrategy: SerializationStrategy<Map<symbol, unknown>> = {
     const out: SerializedObject = {};
     for (const [symId, value] of source) {
       const key = aspectKeyById.get(symId);
-      if (!key || key.typeMap.size === 0) continue;
+      if (!key) continue;
       const v = value as object;
-      const tag = key.typeMap.getKey(v.constructor as Constructor);
-      if (!tag) {
-        throw new Error(
-          `Aspect "${key.name}" value of type ${v.constructor.name} ` +
-            `has no entry in its typeMap`,
-        );
+      if (key.typeMap) {
+        const tag = key.typeMap.getKey(v.constructor as Constructor);
+        if (!tag) {
+          throw new Error(
+            `Aspect "${key.name}" value of type ${v.constructor.name} ` +
+              `has no entry in its typeMap`,
+          );
+        }
+        out[key.name] = { $type: tag, ...serializeFields(v) };
+      } else if (key.ctor) {
+        out[key.name] = serializeFields(v);
       }
-      out[key.name] = { $type: tag, ...serializeFields(v) };
     }
     return Object.keys(out).length === 0 ? undefined : out;
   },
@@ -84,9 +90,16 @@ const aspectsStrategy: SerializationStrategy<Map<symbol, unknown>> = {
       const key = aspectKeyByName.get(name);
       if (!key) throw new Error(`Unknown aspect "${name}"`);
       const r = raw as SerializedObject;
-      const ctor = key.typeMap.get(r.$type as string);
-      if (!ctor) {
-        throw new Error(`Unknown $type "${r.$type}" for aspect "${name}"`);
+      let ctor: Constructor | undefined;
+      if (key.typeMap) {
+        ctor = key.typeMap.get(r.$type as string);
+        if (!ctor) {
+          throw new Error(`Unknown $type "${r.$type}" for aspect "${name}"`);
+        }
+      } else if (key.ctor) {
+        ctor = key.ctor;
+      } else {
+        throw new Error(`Aspect "${name}" has no impl registered`);
       }
       map.set(key.id, deserializeFields(r, ctor));
     }

--- a/packages/core/src/composite/Composite.ts
+++ b/packages/core/src/composite/Composite.ts
@@ -27,7 +27,9 @@ export function Aspect<T extends object>(id: string, key?: AspectKey<T>) {
         );
       }
     } else {
-      aspectRegistry.set(ctor, new AspectKey(id));
+      const newKey = new AspectKey(id);
+      newKey.typeMap.set(id, ctor);
+      aspectRegistry.set(ctor, newKey);
     }
   };
 }

--- a/packages/core/src/composite/Composite.ts
+++ b/packages/core/src/composite/Composite.ts
@@ -21,7 +21,7 @@ const aspectRegistry = new WeakMap<Constructor, AspectKey<unknown>>();
 export function Aspect<T extends object>(id: string, key?: AspectKey<T>) {
   return (ctor: Constructor) => {
     if (key) {
-      if (!key.typeMap) key.typeMap = new BiMap<string, Constructor<T>>();
+      key.typeMap ??= new BiMap<string, Constructor<T>>();
       if (!key.typeMap.set(id, ctor as Constructor<T>)) {
         throw new Error(
           `Aspect impl "${id}" already registered under "${key.name}" ` +

--- a/packages/core/src/composite/Composite.ts
+++ b/packages/core/src/composite/Composite.ts
@@ -2,8 +2,8 @@ import { Constructor } from "../util/Types";
 import { BiMap } from "../util/Algorithms";
 import {
   Property,
-  serialize as serializeFields,
-  deserialize as deserializeFields,
+  serialize,
+  deserialize,
   type SerializedObject,
   type SerializationStrategy,
 } from "../serial/Data";
@@ -77,9 +77,9 @@ const aspectsStrategy: SerializationStrategy<Map<symbol, unknown>> = {
               `has no entry in its typeMap`,
           );
         }
-        out[key.name] = { $type: tag, ...serializeFields(v) };
+        out[key.name] = { $type: tag, ...serialize(v) };
       } else if (key.ctor) {
-        out[key.name] = serializeFields(v);
+        out[key.name] = serialize(v);
       }
     }
     return Object.keys(out).length === 0 ? undefined : out;
@@ -101,7 +101,7 @@ const aspectsStrategy: SerializationStrategy<Map<symbol, unknown>> = {
       } else {
         throw new Error(`Aspect "${name}" has no impl registered`);
       }
-      map.set(key.id, deserializeFields(r, ctor));
+      map.set(key.id, deserialize(r, ctor));
     }
     return map;
   },

--- a/packages/core/src/composite/Composite.ts
+++ b/packages/core/src/composite/Composite.ts
@@ -1,17 +1,7 @@
 import { Constructor } from "../util/Types";
 import { BiMap } from "../util/Algorithms";
-import {
-  Property,
-  serialize,
-  deserialize,
-  type SerializedObject,
-  type SerializationStrategy,
-} from "../serial/Data";
 
 // Aspects
-
-const aspectKeyByName = new Map<string, AspectKey<unknown>>();
-const aspectKeyById = new Map<symbol, AspectKey<unknown>>();
 
 export class AspectKey<T> {
   declare readonly _type: T;
@@ -21,13 +11,8 @@ export class AspectKey<T> {
   typeMap?: BiMap<string, Constructor<T>>;
 
   constructor(name: string) {
-    if (aspectKeyByName.has(name)) {
-      throw new Error(`AspectKey "${name}" already registered`);
-    }
     this.name = name;
     this.id = Symbol(name);
-    aspectKeyByName.set(name, this as AspectKey<unknown>);
-    aspectKeyById.set(this.id, this as AspectKey<unknown>);
   }
 }
 
@@ -60,57 +45,9 @@ export function getAspectKey<T extends object>(ref: AspectRef<T>) {
   return key as AspectKey<T>;
 }
 
-// Aspect-map strategy: encodes Composite.aspects as { [name]: { $type, ...fields } }
-
-const aspectsStrategy: SerializationStrategy<Map<symbol, unknown>> = {
-  serialize(source) {
-    const out: SerializedObject = {};
-    for (const [symId, value] of source) {
-      const key = aspectKeyById.get(symId);
-      if (!key) continue;
-      const v = value as object;
-      if (key.typeMap) {
-        const tag = key.typeMap.getKey(v.constructor as Constructor);
-        if (!tag) {
-          throw new Error(
-            `Aspect "${key.name}" value of type ${v.constructor.name} ` +
-              `has no entry in its typeMap`,
-          );
-        }
-        out[key.name] = { $type: tag, ...serialize(v) };
-      } else if (key.ctor) {
-        out[key.name] = serialize(v);
-      }
-    }
-    return Object.keys(out).length === 0 ? undefined : out;
-  },
-  deserialize(source, current) {
-    const map = current ?? new Map<symbol, unknown>();
-    for (const [name, raw] of Object.entries(source as SerializedObject)) {
-      const key = aspectKeyByName.get(name);
-      if (!key) throw new Error(`Unknown aspect "${name}"`);
-      const r = raw as SerializedObject;
-      let ctor: Constructor | undefined;
-      if (key.typeMap) {
-        ctor = key.typeMap.get(r.$type as string);
-        if (!ctor) {
-          throw new Error(`Unknown $type "${r.$type}" for aspect "${name}"`);
-        }
-      } else if (key.ctor) {
-        ctor = key.ctor;
-      } else {
-        throw new Error(`Aspect "${name}" has no impl registered`);
-      }
-      map.set(key.id, deserialize(r, ctor));
-    }
-    return map;
-  },
-};
-
 // Composite
 
 export class Composite {
-  @Property.Serialize(aspectsStrategy)
   readonly aspects = new Map<symbol, unknown>();
 
   provide<T extends object>(aspect: AspectRef<T>, value: T): void {

--- a/packages/core/src/composite/Composite.ts
+++ b/packages/core/src/composite/Composite.ts
@@ -54,23 +54,3 @@ export class Composite {
     return this.aspects.has(getAspectKey(ref).id);
   }
 }
-
-// Template
-
-export class Template {
-  constructor(
-    readonly name: string,
-    readonly aspects: AspectRef<object>[],
-  ) {}
-
-  /** Throws listing all missing aspects if the composite doesn't satisfy this template. */
-  validate(composite: Composite): void {
-    const missing = this.aspects.filter((a) => !composite.has(a));
-    if (missing.length > 0) {
-      throw new Error(
-        `Composite is missing aspects for template "${this.name}": ` +
-          missing.map((a) => a.name).join(", "),
-      );
-    }
-  }
-}

--- a/packages/core/src/composite/Structure.ts
+++ b/packages/core/src/composite/Structure.ts
@@ -1,12 +1,20 @@
 import { AspectKey, AspectRef, Composite } from "./Composite";
 
+type Entry<T extends object> = [AspectRef<T>, () => T] | [AspectRef<T>];
+
 export function Structure<const Types extends readonly object[]>(
-  ...aspects: { [K in keyof Types]: [AspectRef<Types[K]>, () => Types[K]] }
+  ...entries: { [K in keyof Types]: Entry<Types[K]> }
 ) {
+  const expected = entries.map(([ref]) => ref) as AspectRef<object>[];
   return class extends Composite {
     constructor() {
       super();
-      for (const [ref, provider] of aspects) this.provide(ref, provider());
+      for (const entry of entries) {
+        if (entry.length === 2) this.provide(entry[0], entry[1]());
+      }
+    }
+    validate(): boolean {
+      return expected.every((ref) => this.has(ref));
     }
   };
 }

--- a/packages/core/src/composite/Structure.ts
+++ b/packages/core/src/composite/Structure.ts
@@ -35,11 +35,15 @@ export function Structure<const Types extends readonly object[]>(
     }
   };
 
-  Property.Serialize(makeAspectsStrategy(refs, refsByName))(Klass.prototype, "aspects");
+  Property.Serialize(makeAspectsStrategy(entries as readonly Entry<object>[], refs, refsByName))(
+    Klass.prototype,
+    "aspects",
+  );
   return Klass;
 }
 
 function makeAspectsStrategy(
+  entries: readonly Entry<object>[],
   refs: AspectRef<object>[],
   refsByName: Map<string, AspectRef<object>>,
 ): SerializationStrategy<Map<symbol, unknown>> {
@@ -65,8 +69,15 @@ function makeAspectsStrategy(
       }
       return Object.keys(out).length === 0 ? undefined : out;
     },
-    deserialize(source, current) {
-      const map = current ?? new Map<symbol, unknown>();
+    deserialize(source) {
+      const map = new Map<symbol, unknown>();
+      for (const entry of entries) {
+        if (entry.length !== 2) continue;
+        const key = getAspectKey(entry[0]);
+        if (!key.ctor && !key.typeMap) {
+          map.set(key.id, entry[1]());
+        }
+      }
       for (const [name, raw] of Object.entries(source as SerializedObject)) {
         const ref = refsByName.get(name);
         if (!ref) throw new Error(`Unknown aspect "${name}"`);

--- a/packages/core/src/composite/Structure.ts
+++ b/packages/core/src/composite/Structure.ts
@@ -1,10 +1,4 @@
-import { AspectKey, AspectRef, Composite, getAspectKey } from "./Composite";
-import {
-  serialize as serializeFields,
-  deserialize as deserializeFields,
-  type SerializedObject,
-} from "../serial/Data";
-import { type Constructor } from "../util/Types";
+import { AspectKey, AspectRef, Composite } from "./Composite";
 
 type Entry<T extends object> = [AspectRef<T>, () => T] | [AspectRef<T>];
 
@@ -19,43 +13,8 @@ export function Structure<const Types extends readonly object[]>(
         if (entry.length === 2) this.provide(entry[0], entry[1]());
       }
     }
-
     validate(): boolean {
       return refs.every((ref) => this.has(ref));
-    }
-
-    serialize(): SerializedObject {
-      const out: SerializedObject = {};
-      for (const ref of refs) {
-        const key = getAspectKey(ref);
-        if (key.typeMap.size === 0) continue;
-        if (!this.has(key)) continue;
-        const value = this.get(key) as object;
-        const tag = key.typeMap.getKey(value.constructor as Constructor);
-        if (!tag) {
-          throw new Error(
-            `Aspect "${key.name}" value of type ${value.constructor.name} ` +
-              `has no entry in its typeMap — register with @Aspect(...)`,
-          );
-        }
-        out[key.name] = { $type: tag, ...serializeFields(value) };
-      }
-      return out;
-    }
-
-    deserialize(data: SerializedObject): void {
-      for (const ref of refs) {
-        const key = getAspectKey(ref);
-        if (key.typeMap.size === 0) continue;
-        const raw = data[key.name] as SerializedObject | undefined;
-        if (!raw) continue;
-        const tag = raw.$type as string;
-        const ctor = key.typeMap.get(tag);
-        if (!ctor) {
-          throw new Error(`Unknown $type "${tag}" for aspect "${key.name}"`);
-        }
-        this.provide(key, deserializeFields(raw, ctor));
-      }
     }
   };
 }

--- a/packages/core/src/composite/Structure.ts
+++ b/packages/core/src/composite/Structure.ts
@@ -13,9 +13,9 @@ type Entry<T extends object> = [AspectRef<T>, () => T] | [AspectRef<T>];
 export function Structure<const Types extends readonly object[]>(
   ...entries: { [K in keyof Types]: Entry<Types[K]> }
 ) {
-  const refs = entries.map(([ref]) => ref) as AspectRef<object>[];
   const refsByName = new Map<string, AspectRef<object>>();
-  for (const ref of refs) {
+  for (const entry of entries) {
+    const ref = entry[0];
     const name = getAspectKey(ref).name;
     if (refsByName.has(name)) {
       throw new Error(`Structure has duplicate aspect name "${name}"`);
@@ -31,11 +31,14 @@ export function Structure<const Types extends readonly object[]>(
       }
     }
     validate(): boolean {
-      return refs.every((ref) => this.has(ref));
+      for (const ref of refsByName.values()) {
+        if (!this.has(ref)) return false;
+      }
+      return true;
     }
   };
 
-  Property.Serialize(makeAspectsStrategy(entries as readonly Entry<object>[], refs, refsByName))(
+  Property.Serialize(makeAspectsStrategy(entries as readonly Entry<object>[], refsByName))(
     Klass.prototype,
     "aspects",
   );
@@ -44,13 +47,12 @@ export function Structure<const Types extends readonly object[]>(
 
 function makeAspectsStrategy(
   entries: readonly Entry<object>[],
-  refs: AspectRef<object>[],
   refsByName: Map<string, AspectRef<object>>,
 ): SerializationStrategy<Map<symbol, unknown>> {
   return {
     serialize(source) {
       const out: SerializedObject = {};
-      for (const ref of refs) {
+      for (const ref of refsByName.values()) {
         const key = getAspectKey(ref);
         if (!source.has(key.id)) continue;
         const v = source.get(key.id) as object;

--- a/packages/core/src/composite/Structure.ts
+++ b/packages/core/src/composite/Structure.ts
@@ -1,4 +1,12 @@
-import { AspectKey, AspectRef, Composite } from "./Composite";
+import { AspectKey, AspectRef, Composite, getAspectKey } from "./Composite";
+import {
+  Property,
+  serialize,
+  deserialize,
+  type SerializedObject,
+  type SerializationStrategy,
+} from "../serial/Data";
+import { type Constructor } from "../util/Types";
 
 type Entry<T extends object> = [AspectRef<T>, () => T] | [AspectRef<T>];
 
@@ -6,7 +14,16 @@ export function Structure<const Types extends readonly object[]>(
   ...entries: { [K in keyof Types]: Entry<Types[K]> }
 ) {
   const refs = entries.map(([ref]) => ref) as AspectRef<object>[];
-  return class extends Composite {
+  const refsByName = new Map<string, AspectRef<object>>();
+  for (const ref of refs) {
+    const name = getAspectKey(ref).name;
+    if (refsByName.has(name)) {
+      throw new Error(`Structure has duplicate aspect name "${name}"`);
+    }
+    refsByName.set(name, ref);
+  }
+
+  const Klass = class extends Composite {
     constructor() {
       super();
       for (const entry of entries) {
@@ -16,6 +33,60 @@ export function Structure<const Types extends readonly object[]>(
     validate(): boolean {
       return refs.every((ref) => this.has(ref));
     }
+  };
+
+  Property.Serialize(makeAspectsStrategy(refs, refsByName))(Klass.prototype, "aspects");
+  return Klass;
+}
+
+function makeAspectsStrategy(
+  refs: AspectRef<object>[],
+  refsByName: Map<string, AspectRef<object>>,
+): SerializationStrategy<Map<symbol, unknown>> {
+  return {
+    serialize(source) {
+      const out: SerializedObject = {};
+      for (const ref of refs) {
+        const key = getAspectKey(ref);
+        if (!source.has(key.id)) continue;
+        const v = source.get(key.id) as object;
+        if (key.typeMap) {
+          const tag = key.typeMap.getKey(v.constructor as Constructor);
+          if (!tag) {
+            throw new Error(
+              `Aspect "${key.name}" value of type ${v.constructor.name} ` +
+                `has no entry in its typeMap`,
+            );
+          }
+          out[key.name] = { $type: tag, ...serialize(v) };
+        } else if (key.ctor) {
+          out[key.name] = serialize(v);
+        }
+      }
+      return Object.keys(out).length === 0 ? undefined : out;
+    },
+    deserialize(source, current) {
+      const map = current ?? new Map<symbol, unknown>();
+      for (const [name, raw] of Object.entries(source as SerializedObject)) {
+        const ref = refsByName.get(name);
+        if (!ref) throw new Error(`Unknown aspect "${name}"`);
+        const key = getAspectKey(ref);
+        const r = raw as SerializedObject;
+        let ctor: Constructor | undefined;
+        if (key.typeMap) {
+          ctor = key.typeMap.get(r.$type as string);
+          if (!ctor) {
+            throw new Error(`Unknown $type "${r.$type}" for aspect "${name}"`);
+          }
+        } else if (key.ctor) {
+          ctor = key.ctor;
+        } else {
+          throw new Error(`Aspect "${name}" has no impl registered`);
+        }
+        map.set(key.id, deserialize(r, ctor));
+      }
+      return map;
+    },
   };
 }
 

--- a/packages/core/src/composite/Structure.ts
+++ b/packages/core/src/composite/Structure.ts
@@ -1,11 +1,17 @@
-import { AspectKey, AspectRef, Composite } from "./Composite";
+import { AspectKey, AspectRef, Composite, getAspectKey } from "./Composite";
+import {
+  serialize as serializeFields,
+  deserialize as deserializeFields,
+  type SerializedObject,
+} from "../serial/Data";
+import { type Constructor } from "../util/Types";
 
 type Entry<T extends object> = [AspectRef<T>, () => T] | [AspectRef<T>];
 
 export function Structure<const Types extends readonly object[]>(
   ...entries: { [K in keyof Types]: Entry<Types[K]> }
 ) {
-  const expected = entries.map(([ref]) => ref) as AspectRef<object>[];
+  const refs = entries.map(([ref]) => ref) as AspectRef<object>[];
   return class extends Composite {
     constructor() {
       super();
@@ -13,8 +19,43 @@ export function Structure<const Types extends readonly object[]>(
         if (entry.length === 2) this.provide(entry[0], entry[1]());
       }
     }
+
     validate(): boolean {
-      return expected.every((ref) => this.has(ref));
+      return refs.every((ref) => this.has(ref));
+    }
+
+    serialize(): SerializedObject {
+      const out: SerializedObject = {};
+      for (const ref of refs) {
+        const key = getAspectKey(ref);
+        if (key.typeMap.size === 0) continue;
+        if (!this.has(key)) continue;
+        const value = this.get(key) as object;
+        const tag = key.typeMap.getKey(value.constructor as Constructor);
+        if (!tag) {
+          throw new Error(
+            `Aspect "${key.name}" value of type ${value.constructor.name} ` +
+              `has no entry in its typeMap — register with @Aspect(...)`,
+          );
+        }
+        out[key.name] = { $type: tag, ...serializeFields(value) };
+      }
+      return out;
+    }
+
+    deserialize(data: SerializedObject): void {
+      for (const ref of refs) {
+        const key = getAspectKey(ref);
+        if (key.typeMap.size === 0) continue;
+        const raw = data[key.name] as SerializedObject | undefined;
+        if (!raw) continue;
+        const tag = raw.$type as string;
+        const ctor = key.typeMap.get(tag);
+        if (!ctor) {
+          throw new Error(`Unknown $type "${tag}" for aspect "${key.name}"`);
+        }
+        this.provide(key, deserializeFields(raw, ctor));
+      }
     }
   };
 }

--- a/packages/core/src/dnd/Sheet.test.ts
+++ b/packages/core/src/dnd/Sheet.test.ts
@@ -94,10 +94,10 @@ test("lowering base score refunds points", () => {
 });
 
 test("BaseAbilityScore typemap resolves impls by tag", () => {
-  expect(BaseAbilityScore.typeMap.get("PointBuy")).toBe(PointBuyAbilityScore);
-  expect(BaseAbilityScore.typeMap.get("Static")).toBe(StaticAbilityScore);
-  expect(BaseAbilityScore.typeMap.getKey(PointBuyAbilityScore)).toBe("PointBuy");
-  expect(BaseAbilityScore.typeMap.getKey(StaticAbilityScore)).toBe("Static");
+  expect(BaseAbilityScore.typeMap!.get("PointBuy")).toBe(PointBuyAbilityScore);
+  expect(BaseAbilityScore.typeMap!.get("Static")).toBe(StaticAbilityScore);
+  expect(BaseAbilityScore.typeMap!.getKey(PointBuyAbilityScore)).toBe("PointBuy");
+  expect(BaseAbilityScore.typeMap!.getKey(StaticAbilityScore)).toBe("Static");
 });
 
 test("two-arg @Aspect does not populate aspectRegistry", () => {
@@ -109,10 +109,10 @@ test("duplicate impl registration throws", () => {
   expect(() => Aspect("PointBuy", BaseAbilityScore)(class {})).toThrow();
 });
 
-test("single-arg @Aspect self-registers in own typeMap", () => {
+test("single-arg @Aspect sets ctor and leaves typeMap undefined", () => {
   const idKey = getAspectKey(Id);
-  expect(idKey.typeMap.get("Id")).toBe(Id);
-  expect(idKey.typeMap.getKey(Id)).toBe("Id");
+  expect(idKey.ctor).toBe(Id);
+  expect(idKey.typeMap).toBeUndefined();
 });
 
 test("sheet serializes point buy round-trip", () => {
@@ -125,7 +125,7 @@ test("sheet serializes point buy round-trip", () => {
   const data = serialize(sheet);
   expect(data).toStrictEqual({
     aspects: {
-      Id: { $type: "Id", value: sheet.get(Id).value },
+      Id: { value: sheet.get(Id).value },
       BaseAbilityScore: {
         $type: "PointBuy",
         points: {
@@ -210,7 +210,7 @@ test("deserialize unknown $type throws", () => {
 
 test("deserialize without BaseAbilityScore leaves sheet invalid", () => {
   const sheet = deserialize(
-    { aspects: { Id: { $type: "Id", value: "abc" } } },
+    { aspects: { Id: { value: "abc" } } },
     Sheet,
   );
   expect(sheet.validate()).toBe(false);

--- a/packages/core/src/dnd/Sheet.test.ts
+++ b/packages/core/src/dnd/Sheet.test.ts
@@ -1,13 +1,14 @@
 import { expect, test } from "bun:test";
 import { AbilityScore } from "../stats/AbilityScore";
 import {
-  PointBuyScore,
+  PointBuyAbilityScore,
   StaticAbilityScore,
   BaseAbilityScore,
   POINT_BUY_BUDGET,
 } from "../stats/BaseAbilityScore";
 import { Holder } from "../composite/Structure";
 import { Id } from "../composite/Id";
+import { Aspect, getAspectKey, getAspectTypeMap } from "../composite/Composite";
 import { Sheet } from "./Sheet";
 
 test("sheet provides Id", () => {
@@ -24,13 +25,13 @@ test("sheet provides Holder", () => {
 test("sheet validate reflects BaseAbilityScore presence", () => {
   const sheet = new Sheet();
   expect(sheet.validate()).toBe(false);
-  sheet.provide(BaseAbilityScore, new PointBuyScore());
+  sheet.provide(BaseAbilityScore, new PointBuyAbilityScore());
   expect(sheet.validate()).toBe(true);
 });
 
 test("refresh via Holder applies point buy contributions", () => {
   const sheet = new Sheet();
-  sheet.provide(BaseAbilityScore, new PointBuyScore());
+  sheet.provide(BaseAbilityScore, new PointBuyAbilityScore());
   const score = new AbilityScore();
   sheet.provide(AbilityScore, score);
   score.refresh(sheet);
@@ -58,26 +59,26 @@ test("refresh via Holder applies static contributions", () => {
 });
 
 test("default base scores cost zero points", () => {
-  const scores = new PointBuyScore();
+  const scores = new PointBuyAbilityScore();
   expect(scores.spent()).toBe(0);
   expect(scores.remaining()).toBe(POINT_BUY_BUDGET);
 });
 
 test("set base score spends points", () => {
-  const scores = new PointBuyScore();
+  const scores = new PointBuyAbilityScore();
   scores.set("strength", 9);
   expect(scores.spent()).toBe(9);
   expect(scores.remaining()).toBe(POINT_BUY_BUDGET - 9);
 });
 
 test("set base score throws when invalid cost", () => {
-  const scores = new PointBuyScore();
+  const scores = new PointBuyAbilityScore();
   expect(() => scores.set("strength", 6)).toThrow();
   expect(() => scores.set("strength", -1)).toThrow();
 });
 
 test("set base score throws when over budget", () => {
-  const scores = new PointBuyScore();
+  const scores = new PointBuyAbilityScore();
   scores.set("strength", 9);
   scores.set("dexterity", 9);
   scores.set("constitution", 9);
@@ -85,8 +86,25 @@ test("set base score throws when over budget", () => {
 });
 
 test("lowering base score refunds points", () => {
-  const scores = new PointBuyScore();
+  const scores = new PointBuyAbilityScore();
   scores.set("strength", 7);
   scores.set("strength", 2);
   expect(scores.spent()).toBe(2);
+});
+
+test("BaseAbilityScore typemap resolves impls by tag", () => {
+  const map = getAspectTypeMap(BaseAbilityScore);
+  expect(map.get("PointBuy")).toBe(PointBuyAbilityScore);
+  expect(map.get("Static")).toBe(StaticAbilityScore);
+  expect(map.getKey(PointBuyAbilityScore)).toBe("PointBuy");
+  expect(map.getKey(StaticAbilityScore)).toBe("Static");
+});
+
+test("two-arg @Aspect does not populate aspectRegistry", () => {
+  expect(() => getAspectKey(Id)).not.toThrow();
+  expect(() => getAspectKey(PointBuyAbilityScore)).toThrow();
+});
+
+test("duplicate impl registration throws", () => {
+  expect(() => Aspect("PointBuy", BaseAbilityScore)(class {})).toThrow();
 });

--- a/packages/core/src/dnd/Sheet.test.ts
+++ b/packages/core/src/dnd/Sheet.test.ts
@@ -107,3 +107,108 @@ test("two-arg @Aspect does not populate aspectRegistry", () => {
 test("duplicate impl registration throws", () => {
   expect(() => Aspect("PointBuy", BaseAbilityScore)(class {})).toThrow();
 });
+
+test("single-arg @Aspect self-registers in own typeMap", () => {
+  const idKey = getAspectKey(Id);
+  expect(idKey.typeMap.get("Id")).toBe(Id);
+  expect(idKey.typeMap.getKey(Id)).toBe("Id");
+});
+
+test("sheet serializes point buy round-trip", () => {
+  const sheet = new Sheet();
+  const points = new PointBuyAbilityScore();
+  sheet.provide(BaseAbilityScore, points);
+  points.set("strength", 9);
+  points.set("dexterity", 5);
+
+  const data = sheet.serialize();
+  expect(data).toStrictEqual({
+    Id: { $type: "Id", value: sheet.get(Id).value },
+    BaseAbilityScore: {
+      $type: "PointBuy",
+      points: {
+        strength: 9,
+        dexterity: 5,
+        constitution: 0,
+        intelligence: 0,
+        wisdom: 0,
+        charisma: 0,
+      },
+    },
+  });
+  expect("Holder" in data).toBe(false);
+
+  const restored = new Sheet();
+  restored.deserialize(data);
+  expect(restored.validate()).toBe(true);
+  expect(restored.get(Id).value).toBe(sheet.get(Id).value);
+  const restoredPoints = restored.get(BaseAbilityScore) as PointBuyAbilityScore;
+  expect(restoredPoints.points.strength).toBe(9);
+  expect(restoredPoints.points.dexterity).toBe(5);
+});
+
+test("sheet serializes static score round-trip", () => {
+  const sheet = new Sheet();
+  sheet.provide(
+    BaseAbilityScore,
+    new StaticAbilityScore({
+      strength: 15,
+      dexterity: 14,
+      constitution: 13,
+      intelligence: 12,
+      wisdom: 10,
+      charisma: 8,
+    }),
+  );
+
+  const data = sheet.serialize();
+  expect(data.BaseAbilityScore).toStrictEqual({
+    $type: "Static",
+    scores: {
+      strength: 15,
+      dexterity: 14,
+      constitution: 13,
+      intelligence: 12,
+      wisdom: 10,
+      charisma: 8,
+    },
+  });
+
+  const restored = new Sheet();
+  restored.deserialize(data);
+  expect(restored.validate()).toBe(true);
+  const restoredScores = restored.get(BaseAbilityScore) as StaticAbilityScore;
+  expect(restoredScores.scores.strength).toBe(15);
+  expect(restoredScores.scores.charisma).toBe(8);
+});
+
+test("refresh works on deserialized point buy sheet", () => {
+  const original = new Sheet();
+  original.provide(BaseAbilityScore, new PointBuyAbilityScore());
+  (original.get(BaseAbilityScore) as PointBuyAbilityScore).set("strength", 9);
+  const before = new AbilityScore();
+  original.provide(AbilityScore, before);
+  before.refresh(original);
+
+  const restored = new Sheet();
+  restored.deserialize(original.serialize());
+  const after = new AbilityScore();
+  restored.provide(AbilityScore, after);
+  after.refresh(restored);
+
+  expect(after.scores).toStrictEqual(before.scores);
+});
+
+test("deserialize unknown $type throws", () => {
+  const sheet = new Sheet();
+  expect(() =>
+    sheet.deserialize({ BaseAbilityScore: { $type: "Bogus", points: {} } }),
+  ).toThrow(/Bogus/);
+});
+
+test("deserialize without BaseAbilityScore leaves sheet invalid", () => {
+  const sheet = new Sheet();
+  sheet.deserialize({ Id: { $type: "Id", value: "abc" } });
+  expect(sheet.validate()).toBe(false);
+  expect(sheet.get(Id).value).toBe("abc");
+});

--- a/packages/core/src/dnd/Sheet.test.ts
+++ b/packages/core/src/dnd/Sheet.test.ts
@@ -8,7 +8,7 @@ import {
 } from "../stats/BaseAbilityScore";
 import { Holder } from "../composite/Structure";
 import { Id } from "../composite/Id";
-import { Aspect, getAspectKey, getAspectTypeMap } from "../composite/Composite";
+import { Aspect, getAspectKey } from "../composite/Composite";
 import { Sheet } from "./Sheet";
 
 test("sheet provides Id", () => {
@@ -93,11 +93,10 @@ test("lowering base score refunds points", () => {
 });
 
 test("BaseAbilityScore typemap resolves impls by tag", () => {
-  const map = getAspectTypeMap(BaseAbilityScore);
-  expect(map.get("PointBuy")).toBe(PointBuyAbilityScore);
-  expect(map.get("Static")).toBe(StaticAbilityScore);
-  expect(map.getKey(PointBuyAbilityScore)).toBe("PointBuy");
-  expect(map.getKey(StaticAbilityScore)).toBe("Static");
+  expect(BaseAbilityScore.typeMap.get("PointBuy")).toBe(PointBuyAbilityScore);
+  expect(BaseAbilityScore.typeMap.get("Static")).toBe(StaticAbilityScore);
+  expect(BaseAbilityScore.typeMap.getKey(PointBuyAbilityScore)).toBe("PointBuy");
+  expect(BaseAbilityScore.typeMap.getKey(StaticAbilityScore)).toBe("Static");
 });
 
 test("two-arg @Aspect does not populate aspectRegistry", () => {

--- a/packages/core/src/dnd/Sheet.test.ts
+++ b/packages/core/src/dnd/Sheet.test.ts
@@ -9,6 +9,7 @@ import {
 import { Holder } from "../composite/Structure";
 import { Id } from "../composite/Id";
 import { Aspect, getAspectKey } from "../composite/Composite";
+import { serialize, deserialize } from "../serial/Data";
 import { Sheet } from "./Sheet";
 
 test("sheet provides Id", () => {
@@ -121,25 +122,26 @@ test("sheet serializes point buy round-trip", () => {
   points.set("strength", 9);
   points.set("dexterity", 5);
 
-  const data = sheet.serialize();
+  const data = serialize(sheet);
   expect(data).toStrictEqual({
-    Id: { $type: "Id", value: sheet.get(Id).value },
-    BaseAbilityScore: {
-      $type: "PointBuy",
-      points: {
-        strength: 9,
-        dexterity: 5,
-        constitution: 0,
-        intelligence: 0,
-        wisdom: 0,
-        charisma: 0,
+    aspects: {
+      Id: { $type: "Id", value: sheet.get(Id).value },
+      BaseAbilityScore: {
+        $type: "PointBuy",
+        points: {
+          strength: 9,
+          dexterity: 5,
+          constitution: 0,
+          intelligence: 0,
+          wisdom: 0,
+          charisma: 0,
+        },
       },
     },
   });
-  expect("Holder" in data).toBe(false);
+  expect("Holder" in (data.aspects as object)).toBe(false);
 
-  const restored = new Sheet();
-  restored.deserialize(data);
+  const restored = deserialize(data, Sheet);
   expect(restored.validate()).toBe(true);
   expect(restored.get(Id).value).toBe(sheet.get(Id).value);
   const restoredPoints = restored.get(BaseAbilityScore) as PointBuyAbilityScore;
@@ -161,8 +163,8 @@ test("sheet serializes static score round-trip", () => {
     }),
   );
 
-  const data = sheet.serialize();
-  expect(data.BaseAbilityScore).toStrictEqual({
+  const data = serialize(sheet);
+  expect((data.aspects as { BaseAbilityScore: unknown }).BaseAbilityScore).toStrictEqual({
     $type: "Static",
     scores: {
       strength: 15,
@@ -174,8 +176,7 @@ test("sheet serializes static score round-trip", () => {
     },
   });
 
-  const restored = new Sheet();
-  restored.deserialize(data);
+  const restored = deserialize(data, Sheet);
   expect(restored.validate()).toBe(true);
   const restoredScores = restored.get(BaseAbilityScore) as StaticAbilityScore;
   expect(restoredScores.scores.strength).toBe(15);
@@ -190,8 +191,7 @@ test("refresh works on deserialized point buy sheet", () => {
   original.provide(AbilityScore, before);
   before.refresh(original);
 
-  const restored = new Sheet();
-  restored.deserialize(original.serialize());
+  const restored = deserialize(serialize(original), Sheet);
   const after = new AbilityScore();
   restored.provide(AbilityScore, after);
   after.refresh(restored);
@@ -200,15 +200,19 @@ test("refresh works on deserialized point buy sheet", () => {
 });
 
 test("deserialize unknown $type throws", () => {
-  const sheet = new Sheet();
   expect(() =>
-    sheet.deserialize({ BaseAbilityScore: { $type: "Bogus", points: {} } }),
+    deserialize(
+      { aspects: { BaseAbilityScore: { $type: "Bogus", points: {} } } },
+      Sheet,
+    ),
   ).toThrow(/Bogus/);
 });
 
 test("deserialize without BaseAbilityScore leaves sheet invalid", () => {
-  const sheet = new Sheet();
-  sheet.deserialize({ Id: { $type: "Id", value: "abc" } });
+  const sheet = deserialize(
+    { aspects: { Id: { $type: "Id", value: "abc" } } },
+    Sheet,
+  );
   expect(sheet.validate()).toBe(false);
   expect(sheet.get(Id).value).toBe("abc");
 });

--- a/packages/core/src/dnd/Sheet.test.ts
+++ b/packages/core/src/dnd/Sheet.test.ts
@@ -201,18 +201,12 @@ test("refresh works on deserialized point buy sheet", () => {
 
 test("deserialize unknown $type throws", () => {
   expect(() =>
-    deserialize(
-      { aspects: { BaseAbilityScore: { $type: "Bogus", points: {} } } },
-      Sheet,
-    ),
+    deserialize({ aspects: { BaseAbilityScore: { $type: "Bogus", points: {} } } }, Sheet),
   ).toThrow(/Bogus/);
 });
 
 test("deserialize without BaseAbilityScore leaves sheet invalid", () => {
-  const sheet = deserialize(
-    { aspects: { Id: { value: "abc" } } },
-    Sheet,
-  );
+  const sheet = deserialize({ aspects: { Id: { value: "abc" } } }, Sheet);
   expect(sheet.validate()).toBe(false);
   expect(sheet.get(Id).value).toBe("abc");
 });

--- a/packages/core/src/dnd/Sheet.test.ts
+++ b/packages/core/src/dnd/Sheet.test.ts
@@ -21,6 +21,13 @@ test("sheet provides Holder", () => {
   expect(sheet.has(Holder)).toBe(true);
 });
 
+test("sheet validate reflects BaseAbilityScore presence", () => {
+  const sheet = new Sheet();
+  expect(sheet.validate()).toBe(false);
+  sheet.provide(BaseAbilityScore, new PointBuyScore());
+  expect(sheet.validate()).toBe(true);
+});
+
 test("refresh via Holder applies point buy contributions", () => {
   const sheet = new Sheet();
   sheet.provide(BaseAbilityScore, new PointBuyScore());

--- a/packages/core/src/dnd/Sheet.ts
+++ b/packages/core/src/dnd/Sheet.ts
@@ -1,5 +1,10 @@
 import { Structure, Holder } from "../composite/Structure";
 import { Id } from "../composite/Id";
 import { AspectHolder } from "../composite/AspectHolder";
+import { BaseAbilityScore } from "../stats/BaseAbilityScore";
 
-export const Sheet = Structure([Id, () => new Id()], [Holder, () => new AspectHolder()]);
+export const Sheet = Structure(
+  [Id, () => new Id()],
+  [Holder, () => new AspectHolder()],
+  [BaseAbilityScore],
+);

--- a/packages/core/src/serial/Data.ts
+++ b/packages/core/src/serial/Data.ts
@@ -7,7 +7,7 @@ export type SerializedObject = Record<string, unknown>;
 
 export interface SerializationStrategy<T = any> {
   serialize(source: T): any;
-  deserialize(source: any): T;
+  deserialize(source: any, current?: T): T;
 }
 
 // --- Property data ---
@@ -15,9 +15,23 @@ export interface SerializationStrategy<T = any> {
 type PropertyData = Record<string, SerializationStrategy>;
 const PROPERTY_SYMBOL = Symbol("properties");
 
-function getPropertyData(target: object): PropertyData {
+function ownPropertyData(target: object): PropertyData {
   const proto = (target as any).constructor?.prototype ?? target;
   return getMetadata<PropertyData>(proto, PROPERTY_SYMBOL, {});
+}
+
+function getPropertyData(target: object): PropertyData {
+  const chain: object[] = [];
+  let proto: object | null = Object.getPrototypeOf(target);
+  while (proto && proto !== Object.prototype) {
+    chain.push(proto);
+    proto = Object.getPrototypeOf(proto);
+  }
+  const merged: PropertyData = {};
+  for (let i = chain.length - 1; i >= 0; i--) {
+    Object.assign(merged, getMetadata<PropertyData>(chain[i]!, PROPERTY_SYMBOL, {}));
+  }
+  return merged;
 }
 
 // --- serialize / deserialize ---
@@ -28,7 +42,8 @@ export function serialize(target: object): SerializedObject {
   for (const [label, strategy] of Object.entries(properties)) {
     const value = (target as SerializedObject)[label];
     if (value === undefined) continue;
-    res[label] = strategy.serialize(value);
+    const out = strategy.serialize(value);
+    if (out !== undefined) res[label] = out;
   }
   return res;
 }
@@ -42,7 +57,8 @@ export function deserialize<T extends object>(
   for (const [label, strategy] of Object.entries(properties)) {
     const value = source[label];
     if (value === undefined) continue;
-    (res as SerializedObject)[label] = strategy.deserialize(value);
+    const current = (res as SerializedObject)[label];
+    (res as SerializedObject)[label] = strategy.deserialize(value, current);
   }
   return res;
 }
@@ -107,12 +123,12 @@ function getStrategy(
 export namespace Property {
   export function Serialize(strategy: SerializationStrategy): PropertyDecorator {
     return (target: object, key: string | symbol) => {
-      getPropertyData(target)[key as string] = strategy;
+      ownPropertyData(target)[key as string] = strategy;
     };
   }
 
   export const Primitive: PropertyDecorator = (target, key) => {
-    getPropertyData(target)[key as string] = PrimitiveStrategy();
+    ownPropertyData(target)[key as string] = PrimitiveStrategy();
   };
 
   export function Class<T extends object>(constructor: Constructor<T>): PropertyDecorator {

--- a/packages/core/src/serial/Data.ts
+++ b/packages/core/src/serial/Data.ts
@@ -7,7 +7,7 @@ export type SerializedObject = Record<string, unknown>;
 
 export interface SerializationStrategy<T = any> {
   serialize(source: T): any;
-  deserialize(source: any, current?: T): T;
+  deserialize(source: any): T;
 }
 
 // --- Property data ---
@@ -57,8 +57,7 @@ export function deserialize<T extends object>(
   for (const [label, strategy] of Object.entries(properties)) {
     const value = source[label];
     if (value === undefined) continue;
-    const current = (res as SerializedObject)[label];
-    (res as SerializedObject)[label] = strategy.deserialize(value, current);
+    (res as SerializedObject)[label] = strategy.deserialize(value);
   }
   return res;
 }

--- a/packages/core/src/stats/BaseAbilityScore.ts
+++ b/packages/core/src/stats/BaseAbilityScore.ts
@@ -1,4 +1,5 @@
 import { Aspect, AspectKey, Composite } from "../composite/Composite";
+import { Property } from "../serial/Data";
 import { enumMap } from "../util/Types";
 import { type Ability, Abilities, AbilityScore, AbilityScoreContributor } from "./AbilityScore";
 
@@ -38,6 +39,7 @@ export const POINT_BUY_BUDGET = 27;
 
 @Aspect("PointBuy", BaseAbilityScore)
 export class PointBuyAbilityScore extends AbstractBaseAbilityScore {
+  @Property.Primitive
   points: Record<Ability, number> = enumMap(Abilities, (_) => 0);
 
   get scores(): Record<Ability, number> {
@@ -63,7 +65,11 @@ export class PointBuyAbilityScore extends AbstractBaseAbilityScore {
 
 @Aspect("Static", BaseAbilityScore)
 export class StaticAbilityScore extends AbstractBaseAbilityScore {
-  constructor(readonly scores: Record<Ability, number>) {
+  @Property.Primitive
+  readonly scores: Record<Ability, number>;
+
+  constructor(scores: Record<Ability, number> = enumMap(Abilities, (_) => 0)) {
     super();
+    this.scores = scores;
   }
 }

--- a/packages/core/src/stats/BaseAbilityScore.ts
+++ b/packages/core/src/stats/BaseAbilityScore.ts
@@ -1,4 +1,4 @@
-import { AspectKey, Composite } from "../composite/Composite";
+import { Aspect, AspectKey, Composite } from "../composite/Composite";
 import { enumMap } from "../util/Types";
 import { type Ability, Abilities, AbilityScore, AbilityScoreContributor } from "./AbilityScore";
 
@@ -36,7 +36,8 @@ const POINT_BUY_SCORES: Record<number, number> = {
 
 export const POINT_BUY_BUDGET = 27;
 
-export class PointBuyScore extends AbstractBaseAbilityScore {
+@Aspect("PointBuy", BaseAbilityScore)
+export class PointBuyAbilityScore extends AbstractBaseAbilityScore {
   points: Record<Ability, number> = enumMap(Abilities, (_) => 0);
 
   get scores(): Record<Ability, number> {
@@ -60,6 +61,7 @@ export class PointBuyScore extends AbstractBaseAbilityScore {
   }
 }
 
+@Aspect("Static", BaseAbilityScore)
 export class StaticAbilityScore extends AbstractBaseAbilityScore {
   constructor(readonly scores: Record<Ability, number>) {
     super();

--- a/packages/core/src/util/Algorithms.ts
+++ b/packages/core/src/util/Algorithms.ts
@@ -27,10 +27,6 @@ export class BiMap<K, V> {
     return this.backward.has(v);
   }
 
-  get size(): number {
-    return this.forward.size;
-  }
-
   inverse(): BiMap<V, K> {
     return new BiMap(this.backward, this.forward);
   }

--- a/packages/core/src/util/Algorithms.ts
+++ b/packages/core/src/util/Algorithms.ts
@@ -27,6 +27,10 @@ export class BiMap<K, V> {
     return this.backward.has(v);
   }
 
+  get size(): number {
+    return this.forward.size;
+  }
+
   inverse(): BiMap<V, K> {
     return new BiMap(this.backward, this.forward);
   }

--- a/packages/playground/src/Main.ts
+++ b/packages/playground/src/Main.ts
@@ -1,11 +1,11 @@
 import { Sheet } from "@atelier/core/dnd/Sheet";
 import { Id } from "@atelier/core/composite/Id";
 import { AbilityScore } from "@atelier/core/stats/AbilityScore";
-import { BaseAbilityScore, PointBuyScore } from "@atelier/core/stats/BaseAbilityScore";
+import { BaseAbilityScore, PointBuyAbilityScore } from "@atelier/core/stats/BaseAbilityScore";
 
 const sheet = new Sheet();
 const score = new AbilityScore();
-sheet.provide(BaseAbilityScore, new PointBuyScore());
+sheet.provide(BaseAbilityScore, new PointBuyAbilityScore());
 sheet.provide(AbilityScore, score);
 
 score.refresh(sheet);


### PR DESCRIPTION
Structure entries now accept [AspectRef] without a thunk to declare an
expected-but-not-provided aspect. The returned class auto-generates a
validate() method that reports whether every declared aspect (provided +
expected) is present, eliminating the per-kind boilerplate the separate
Template class would have required. Sheet now declares BaseAbilityScore
as an empty entry, surfacing the contract that every Sheet needs a
concrete BaseAbilityScore (PointBuy/Static/...) provided by content.

https://claude.ai/code/session_01A6Eti62K6JUg1QtKxxttcQ