### PR TITLE
Implement skill score projection and transient aspect handling

### DIFF
--- a/docs/CORE.md
+++ b/docs/CORE.md
@@ -27,13 +27,16 @@ mechanism, applied fractally at every level (a scope of entities, a composite of
 
 ## Aspect\<T>
 
-A typed capability slot. The primitive everything builds on.
+A typed capability slot. The primitive everything builds on. The slot itself is an
+`AspectKey<T>`; the companion `@Aspect("Name")` decorator registers a class as a
+(non-polymorphic) aspect under an auto-created key, so the class can be passed directly
+wherever an aspect ref is expected.
 
 ```ts
-const HpAspect = new Aspect<HitPoints>("HitPoints");
+const HpAspect = new AspectKey<HitPoints>("HitPoints");
 ```
 
-An `Aspect` has a name that doubles as the map key and the **stable serialization key**.
+An aspect has a name that doubles as the map key and the **stable serialization key**.
 Names must be unique within a containing `Structure` type — the `Structure` constructor
 detects duplicates at definition time.
 
@@ -75,9 +78,11 @@ const sheet = new Sheet(); // Id and Holder already provided
 Each entry is `[AspectRef, () => T]`. The thunk is called once per constructor invocation,
 so every instance gets its own fresh aspect values — no shared state.
 
-`Structure` imposes no required aspects and performs no validation. It is purely a
-convenience over calling `provide` manually in a subclass constructor. Validation (once
-needed) lives in a separate Template or StructureAspect, not inside `Structure` itself.
+`Structure` imposes no _required_ aspects — it never blocks construction or serialization on
+a missing one. It does expose a `validate()` method returning whether every aspect declared
+in the structure is currently present (the "is this composite complete enough to run?"
+check). Richer, typed validation and "what is this?" identification remain the future
+Template / StructureAspect direction below, not part of `Structure` today.
 
 ---
 
@@ -176,8 +181,10 @@ This is what makes prefabs reusable without ID collisions.
 
 ## Template / StructureAspect
 
-Declares the aspects an entity type is expected to have. Used for validation and "what is
-this?" identification. `Template.validate(composite)` throws listing all missing aspects.
+Declares the aspects an entity type is expected to have, for validation and "what is this?"
+identification. Today the presence check lives on the structure itself — `Structure.validate()`
+returns a boolean for whether every declared aspect is present. A dedicated Template that
+throws listing all missing aspects is future direction.
 
 The long-term direction is a **StructureAspect**: structure becomes an aspect carried by the
 composite (kind = item / trait / monster / prop / sheet, plus the expected aspect set) rather
@@ -213,7 +220,7 @@ Scope.fromPrefab(BandOfCultists)
 
 ## Event System
 
-Local events use `createEvent`, `@Subscribe`, `Emitter` — unchanged from original impl.
+Local events use `createEvent`, `@Subscribe`, and `emit` — unchanged from original impl.
 Network events extend this for the WS boundary:
 
 ```ts
@@ -232,10 +239,16 @@ advanced, chat).
 
 ## Stat Contribution
 
-Computed stats (ability scores, and later AC, saves, skills) are a **pure projection** over
-a set of contributors. Anything that writes to a stat exposes the contributor capability and
-is discovered by capability query over the owning composite's children (via `Holder`); the
-computed stat aspect rebuilds itself by gathering and folding those contributions.
+Computed stats (ability scores and skills today; AC, saves, etc. later) are a **pure
+projection** over a set of contributors. Anything that writes to a stat exposes the
+contributor capability and is discovered by capability query over the owning composite's
+children (via `Holder`); the computed stat aspect rebuilds itself by gathering and folding
+those contributions.
+
+Projections **chain**: a computed stat can itself be a contributor to another. The computed
+`AbilityScore` is a `SkillContributor` that folds each ability's modifier into its governed
+skills. Its `apply` reads `this.scores` at evaluation time, so it sees the already-computed
+ability scores — the thunk-at-evaluation-time contract below is exactly what makes this safe.
 
 Key commitments (these are the content-facing contract — expensive to change because every
 piece of content is written against them):
@@ -287,7 +300,11 @@ individually consistent.
 ### Transient-by-default and the purity law
 
 Aspects are **transient by default**. An aspect persists only the fields it explicitly
-decorates with `@Property`; everything else is rebuilt on load.
+decorates with `@Property`; everything else is rebuilt on load. The rule is purely about
+`@Property` presence, so even a class-backed aspect registered via `@Aspect` (e.g. the
+computed `AbilityScore`/`SkillScore`) is transient when it declares no persisted fields: it
+serializes to nothing and is omitted from the output, and `Structure` rebuilds it to its
+default by re-running its factory for any declared aspect absent from the serialized data.
 
 **The purity law:** _if it serializes, the serializer can reconstruct it; if it is transient,
 it must be a pure function of the persisted aspects._ A transient aspect (e.g. computed
@@ -302,8 +319,8 @@ line) instead of a rewrite. Randomness is already handled this way: rolls are lo
 events whose results are persisted as fixed values, so they enter folds as constants, never as
 re-rolled functions.
 
-Post-deserialization, an init pass fires on each reconstructed object so derived/transient
-fields can be recomputed from the persisted ones.
+Recomputing derived values from the persisted contributors (e.g. `AbilityScore.refresh`) is
+an explicit, on-demand step — there is no automatic post-load recompute pass.
 
 ---
 

--- a/docs/CORE.md
+++ b/docs/CORE.md
@@ -81,8 +81,7 @@ so every instance gets its own fresh aspect values — no shared state.
 `Structure` imposes no _required_ aspects — it never blocks construction or serialization on
 a missing one. It does expose a `validate()` method returning whether every aspect declared
 in the structure is currently present (the "is this composite complete enough to run?"
-check). Richer, typed validation and "what is this?" identification remain the future
-Template / StructureAspect direction below, not part of `Structure` today.
+check).
 
 ---
 
@@ -176,25 +175,6 @@ class Links {
 At prefab definition time, IDs are local strings (`'leader'`, `'follower_1'`).
 At stamp time, a resolution pass rewrites all `CompositeRef.id` fields from local → absolute UUIDs.
 This is what makes prefabs reusable without ID collisions.
-
----
-
-## Template / StructureAspect
-
-Declares the aspects an entity type is expected to have, for validation and "what is this?"
-identification. Today the presence check lives on the structure itself — `Structure.validate()`
-returns a boolean for whether every declared aspect is present. A dedicated Template that
-throws listing all missing aspects is future direction.
-
-The long-term direction is a **StructureAspect**: structure becomes an aspect carried by the
-composite (kind = item / trait / monster / prop / sheet, plus the expected aspect set) rather
-than an external object the composite is checked against. Where the StructureAspect is
-expected to be present it is _assumed_ present — its absence is a type error, consistent with
-the "missing aspect = content bug = throw" stance.
-
-StructureAspect is **derived, not declared twice**: the serializer generates the necessary
-structural information from the `@Property` declarations rather than the author maintaining a
-separate schema. (Not built yet — merged into `Structure` when complexity demands it.)
 
 ---
 

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -134,8 +134,8 @@ explain.)
   composite-substrate model (everything is a composite, capabilities are aspects, discovery is
   by capability query at every level) is an ECS-style pattern, adopted because the _uniformity_
   it buys — one substrate, one discovery primitive, one extension mechanism — is worth the cost
-  of giving up some static-type legibility (recovered where needed via StructureAspect and
-  content-author view wrappers). This note is kept rather than deleted so the reversal is on the
+  of giving up some static-type legibility (recovered where needed via content-author view
+  wrappers). This note is kept rather than deleted so the reversal is on the
   record; the original concern about serialization is addressed by the transient-by-default
   purity law in `CORE.md` (transient state is a pure function of persisted state).
 

--- a/packages/core/src/composite/Structure.ts
+++ b/packages/core/src/composite/Structure.ts
@@ -34,6 +34,17 @@ export function Structure<const Types extends readonly object[]>(
   return Klass;
 }
 
+// A serialized aspect carries no persisted state when it is absent or an empty plain object.
+function isEmpty(value: unknown): boolean {
+  return (
+    value === undefined ||
+    (typeof value === "object" &&
+      value !== null &&
+      value.constructor === Object &&
+      Object.keys(value).length === 0)
+  );
+}
+
 function AspectStrategy(
   entries: readonly Entry<object>[],
   refsByName: Map<string, AspectRef<object>>,
@@ -49,18 +60,23 @@ function AspectStrategy(
         const key = getAspectKey(ref);
         if (!source.has(key)) continue;
         const strategy = strategyFor(key);
-        if (strategy) out.set(key, strategy.serialize(source.get(key)));
+        if (!strategy) continue;
+        // An aspect with no @Property fields serializes to an empty object: it persists
+        // nothing and is transient. Omit it; its factory rebuilds it on load.
+        const value = strategy.serialize(source.get(key));
+        if (!isEmpty(value)) out.set(key, value);
       }
       return out.size === 0 ? undefined : out;
     },
     deserialize(source) {
+      const data = source as Map<AspectKey<object>, unknown>;
       const map = new Map<AspectKey<object>, unknown>();
+      // Rebuild every factoried aspect that was not persisted (transients, defaults).
       for (const [aspect, factory] of entries) {
-        if (factory && !strategyFor(getAspectKey(aspect))) {
-          map.set(getAspectKey(aspect), factory());
-        }
+        const key = getAspectKey(aspect);
+        if (factory && !data.has(key)) map.set(key, factory());
       }
-      for (const [key, raw] of source as Map<AspectKey<object>, unknown>) {
+      for (const [key, raw] of data) {
         if (!refsByName.has(key.name)) throw new Error(`Unknown aspect "${key.name}"`);
         const strategy = strategyFor(key);
         if (!strategy) throw new Error(`Aspect "${key.name}" has no impl registered`);

--- a/packages/core/src/composite/Structure.ts
+++ b/packages/core/src/composite/Structure.ts
@@ -1,5 +1,6 @@
 import { AspectKey, AspectRef, Composite, getAspectKey } from "./Composite";
 import { Property, getStrategy, type SerializationStrategy } from "../serial/Data";
+import { isEmpty } from "../util/Util";
 
 type Entry<T extends object> = [AspectRef<T>, () => T] | [AspectRef<T>];
 
@@ -32,17 +33,6 @@ export function Structure<const Types extends readonly object[]>(
 
   Property.Serialize(AspectStrategy(entries, aspectNames))(Klass.prototype, "aspects");
   return Klass;
-}
-
-// A serialized aspect carries no persisted state when it is absent or an empty plain object.
-function isEmpty(value: unknown): boolean {
-  return (
-    value === undefined ||
-    (typeof value === "object" &&
-      value !== null &&
-      value.constructor === Object &&
-      Object.keys(value).length === 0)
-  );
 }
 
 function AspectStrategy(

--- a/packages/core/src/dnd/Sheet.test.ts
+++ b/packages/core/src/dnd/Sheet.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "bun:test";
-import { AbilityScore } from "../stats/AbilityScore";
+import { AbilityScore, abilityModifier } from "../stats/AbilityScore";
+import { SkillScore } from "../stats/Stats";
 import {
   PointBuyAbilityScore,
   StaticAbilityScore,
@@ -56,6 +57,41 @@ test("refresh via Holder applies static contributions", () => {
   score.refresh(sheet);
   expect(score.scores.strength).toBe(15);
   expect(score.scores.charisma).toBe(8);
+});
+
+test("abilityModifier computes 5e modifier", () => {
+  expect(abilityModifier(8)).toBe(-1);
+  expect(abilityModifier(10)).toBe(0);
+  expect(abilityModifier(14)).toBe(2);
+  expect(abilityModifier(15)).toBe(2);
+});
+
+test("SkillScore refresh applies ability modifiers to governed skills", () => {
+  const sheet = new Sheet();
+  sheet.provide(
+    BaseAbilityScore,
+    new StaticAbilityScore({
+      strength: 15,
+      dexterity: 14,
+      constitution: 13,
+      intelligence: 12,
+      wisdom: 10,
+      charisma: 8,
+    }),
+  );
+  const score = new AbilityScore();
+  sheet.provide(AbilityScore, score);
+  score.refresh(sheet);
+
+  const skills = new SkillScore();
+  sheet.provide(SkillScore, skills);
+  skills.refresh(sheet);
+
+  expect(skills.scores.athletics).toBe(2); // STR 15 -> +2
+  expect(skills.scores.acrobatics).toBe(2); // DEX 14 -> +2
+  expect(skills.scores.stealth).toBe(2); // DEX 14 -> +2
+  expect(skills.scores.deception).toBe(-1); // CHA 8 -> -1
+  expect(skills.scores.insight).toBe(0); // WIS 10 -> +0
 });
 
 test("default base scores cost zero points", () => {

--- a/packages/core/src/dnd/Sheet.test.ts
+++ b/packages/core/src/dnd/Sheet.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "bun:test";
-import { AbilityScore, abilityModifier } from "../stats/AbilityScore";
-import { SkillScore } from "../stats/Stats";
+import { AbilityScore, ComputedAbilityScore, abilityModifier } from "../stats/AbilityScore";
+import { ComputedSkillScore, SkillScore } from "../stats/Stats";
 import {
   PointBuyAbilityScore,
   StaticAbilityScore,
@@ -33,7 +33,7 @@ test("sheet validate reflects BaseAbilityScore presence", () => {
 test("refresh via Holder applies point buy contributions", () => {
   const sheet = new Sheet();
   sheet.provide(BaseAbilityScore, new PointBuyAbilityScore());
-  const score = new AbilityScore();
+  const score = new ComputedAbilityScore();
   sheet.provide(AbilityScore, score);
   score.refresh(sheet);
   expect(score.scores.strength).toBe(8);
@@ -52,7 +52,7 @@ test("refresh via Holder applies static contributions", () => {
       charisma: 8,
     }),
   );
-  const score = new AbilityScore();
+  const score = new ComputedAbilityScore();
   sheet.provide(AbilityScore, score);
   score.refresh(sheet);
   expect(score.scores.strength).toBe(15);
@@ -79,11 +79,11 @@ test("SkillScore refresh applies ability modifiers to governed skills", () => {
       charisma: 8,
     }),
   );
-  const score = new AbilityScore();
+  const score = new ComputedAbilityScore();
   sheet.provide(AbilityScore, score);
   score.refresh(sheet);
 
-  const skills = new SkillScore();
+  const skills = new ComputedSkillScore();
   sheet.provide(SkillScore, skills);
   skills.refresh(sheet);
 
@@ -182,6 +182,24 @@ test("sheet serializes point buy round-trip", () => {
   expect(restoredPoints.points.dexterity).toBe(5);
 });
 
+test("computed AbilityScore and SkillScore are transient (not serialized)", () => {
+  const sheet = new Sheet();
+  sheet.provide(BaseAbilityScore, new PointBuyAbilityScore());
+  // both are auto-provided by the Sheet structure
+  expect(sheet.has(AbilityScore)).toBe(true);
+  expect(sheet.has(SkillScore)).toBe(true);
+
+  const aspects = serialize(sheet).aspects as Map<object, unknown>;
+  expect(aspects.has(AbilityScore)).toBe(false);
+  expect(aspects.has(SkillScore)).toBe(false);
+  expect(aspects.has(Holder)).toBe(false);
+
+  // regenerated on load even though they were never serialized
+  const restored = deserialize(serialize(sheet), Sheet);
+  expect(restored.has(AbilityScore)).toBe(true);
+  expect(restored.has(SkillScore)).toBe(true);
+});
+
 test("sheet serializes static score round-trip", () => {
   const sheet = new Sheet();
   sheet.provide(
@@ -220,12 +238,12 @@ test("refresh works on deserialized point buy sheet", () => {
   const original = new Sheet();
   original.provide(BaseAbilityScore, new PointBuyAbilityScore());
   (original.get(BaseAbilityScore) as PointBuyAbilityScore).set("strength", 9);
-  const before = new AbilityScore();
+  const before = new ComputedAbilityScore();
   original.provide(AbilityScore, before);
   before.refresh(original);
 
   const restored = deserialize(serialize(original), Sheet);
-  const after = new AbilityScore();
+  const after = new ComputedAbilityScore();
   restored.provide(AbilityScore, after);
   after.refresh(restored);
 

--- a/packages/core/src/dnd/Sheet.test.ts
+++ b/packages/core/src/dnd/Sheet.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "bun:test";
-import { AbilityScore, ComputedAbilityScore, abilityModifier } from "../stats/AbilityScore";
-import { ComputedSkillScore, SkillScore } from "../stats/Stats";
+import { AbilityScore, abilityModifier } from "../stats/AbilityScore";
+import { SkillScore } from "../stats/Stats";
 import {
   PointBuyAbilityScore,
   StaticAbilityScore,
@@ -33,7 +33,7 @@ test("sheet validate reflects BaseAbilityScore presence", () => {
 test("refresh via Holder applies point buy contributions", () => {
   const sheet = new Sheet();
   sheet.provide(BaseAbilityScore, new PointBuyAbilityScore());
-  const score = new ComputedAbilityScore();
+  const score = new AbilityScore();
   sheet.provide(AbilityScore, score);
   score.refresh(sheet);
   expect(score.scores.strength).toBe(8);
@@ -52,7 +52,7 @@ test("refresh via Holder applies static contributions", () => {
       charisma: 8,
     }),
   );
-  const score = new ComputedAbilityScore();
+  const score = new AbilityScore();
   sheet.provide(AbilityScore, score);
   score.refresh(sheet);
   expect(score.scores.strength).toBe(15);
@@ -79,11 +79,11 @@ test("SkillScore refresh applies ability modifiers to governed skills", () => {
       charisma: 8,
     }),
   );
-  const score = new ComputedAbilityScore();
+  const score = new AbilityScore();
   sheet.provide(AbilityScore, score);
   score.refresh(sheet);
 
-  const skills = new ComputedSkillScore();
+  const skills = new SkillScore();
   sheet.provide(SkillScore, skills);
   skills.refresh(sheet);
 
@@ -190,8 +190,8 @@ test("computed AbilityScore and SkillScore are transient (not serialized)", () =
   expect(sheet.has(SkillScore)).toBe(true);
 
   const aspects = serialize(sheet).aspects as Map<object, unknown>;
-  expect(aspects.has(AbilityScore)).toBe(false);
-  expect(aspects.has(SkillScore)).toBe(false);
+  expect(aspects.has(getAspectKey(AbilityScore))).toBe(false);
+  expect(aspects.has(getAspectKey(SkillScore))).toBe(false);
   expect(aspects.has(Holder)).toBe(false);
 
   // regenerated on load even though they were never serialized
@@ -238,12 +238,12 @@ test("refresh works on deserialized point buy sheet", () => {
   const original = new Sheet();
   original.provide(BaseAbilityScore, new PointBuyAbilityScore());
   (original.get(BaseAbilityScore) as PointBuyAbilityScore).set("strength", 9);
-  const before = new ComputedAbilityScore();
+  const before = new AbilityScore();
   original.provide(AbilityScore, before);
   before.refresh(original);
 
   const restored = deserialize(serialize(original), Sheet);
-  const after = new ComputedAbilityScore();
+  const after = new AbilityScore();
   restored.provide(AbilityScore, after);
   after.refresh(restored);
 

--- a/packages/core/src/dnd/Sheet.ts
+++ b/packages/core/src/dnd/Sheet.ts
@@ -1,9 +1,13 @@
 import { AspectHolder, Holder, Id } from "../composite/Aspects";
 import { Structure } from "../composite/Structure";
+import { AbilityScore, ComputedAbilityScore } from "../stats/AbilityScore";
 import { BaseAbilityScore } from "../stats/BaseAbilityScore";
+import { ComputedSkillScore, SkillScore } from "../stats/Stats";
 
 export const Sheet = Structure(
   [Id, () => new Id()],
   [Holder, () => new AspectHolder()],
   [BaseAbilityScore],
+  [AbilityScore, () => new ComputedAbilityScore()],
+  [SkillScore, () => new ComputedSkillScore()],
 );

--- a/packages/core/src/dnd/Sheet.ts
+++ b/packages/core/src/dnd/Sheet.ts
@@ -1,13 +1,13 @@
 import { AspectHolder, Holder, Id } from "../composite/Aspects";
 import { Structure } from "../composite/Structure";
-import { AbilityScore, ComputedAbilityScore } from "../stats/AbilityScore";
+import { AbilityScore } from "../stats/AbilityScore";
 import { BaseAbilityScore } from "../stats/BaseAbilityScore";
-import { ComputedSkillScore, SkillScore } from "../stats/Stats";
+import { SkillScore } from "../stats/Stats";
 
 export const Sheet = Structure(
   [Id, () => new Id()],
   [Holder, () => new AspectHolder()],
   [BaseAbilityScore],
-  [AbilityScore, () => new ComputedAbilityScore()],
-  [SkillScore, () => new ComputedSkillScore()],
+  [AbilityScore, () => new AbilityScore()],
+  [SkillScore, () => new SkillScore()],
 );

--- a/packages/core/src/stats/AbilityScore.ts
+++ b/packages/core/src/stats/AbilityScore.ts
@@ -1,5 +1,5 @@
 import { Holder } from "../composite/Aspects";
-import { AspectKey, Composite } from "../composite/Composite";
+import { Aspect, AspectKey, Composite } from "../composite/Composite";
 import { enumMap } from "../util/Types";
 import { AbilitySkills, SkillContributor, type SkillScore } from "./Stats";
 
@@ -26,16 +26,10 @@ export function abilityModifier(score: number): number {
   return Math.floor((score - 10) / 2);
 }
 
-export interface AbilityScore {
-  scores: Record<Ability, number>;
-  refresh(sheet: Composite): void;
-}
-
-export const AbilityScore = new AspectKey<AbilityScore>("AbilityScore");
-
-// Computed projection over the sheet's AbilityScoreContributors. Transient: holds no
-// persisted state, regenerated on load and recomputed via refresh (see CORE.md).
-export class ComputedAbilityScore extends Composite implements AbilityScore {
+// Computed projection over the sheet's AbilityScoreContributors. Transient: it declares no
+// @Property fields, so it is never serialized and is rebuilt on load (see CORE.md).
+@Aspect("AbilityScore")
+export class AbilityScore extends Composite {
   scores: Record<Ability, number> = enumMap(Abilities, (_) => 0);
 
   constructor() {

--- a/packages/core/src/stats/AbilityScore.ts
+++ b/packages/core/src/stats/AbilityScore.ts
@@ -1,6 +1,7 @@
 import { Holder } from "../composite/Aspects";
 import { Aspect, AspectKey, Composite } from "../composite/Composite";
 import { enumMap } from "../util/Types";
+import { AbilitySkills, SkillContributor, type SkillScore } from "./Stats";
 
 export const Abilities = [
   "strength",
@@ -21,9 +22,26 @@ export const AbilityLabels: Record<Ability, string> = {
   charisma: "Charisma",
 };
 
+export function abilityModifier(score: number): number {
+  return Math.floor((score - 10) / 2);
+}
+
 @Aspect("AbilityScore")
-export class AbilityScore {
+export class AbilityScore extends Composite {
   scores: Record<Ability, number> = enumMap(Abilities, (_) => 0);
+
+  constructor() {
+    super();
+    this.provide(SkillContributor, {
+      source: this,
+      apply: (skill: SkillScore) => {
+        for (const ability of Abilities) {
+          const mod = abilityModifier(this.scores[ability]);
+          for (const s of AbilitySkills[ability]) skill.scores[s] += mod;
+        }
+      },
+    });
+  }
 
   refresh(sheet: Composite): void {
     for (const child of sheet.get(Holder).children(sheet)) {

--- a/packages/core/src/stats/AbilityScore.ts
+++ b/packages/core/src/stats/AbilityScore.ts
@@ -1,5 +1,5 @@
 import { Holder } from "../composite/Aspects";
-import { Aspect, AspectKey, Composite } from "../composite/Composite";
+import { AspectKey, Composite } from "../composite/Composite";
 import { enumMap } from "../util/Types";
 import { AbilitySkills, SkillContributor, type SkillScore } from "./Stats";
 
@@ -26,8 +26,16 @@ export function abilityModifier(score: number): number {
   return Math.floor((score - 10) / 2);
 }
 
-@Aspect("AbilityScore")
-export class AbilityScore extends Composite {
+export interface AbilityScore {
+  scores: Record<Ability, number>;
+  refresh(sheet: Composite): void;
+}
+
+export const AbilityScore = new AspectKey<AbilityScore>("AbilityScore");
+
+// Computed projection over the sheet's AbilityScoreContributors. Transient: holds no
+// persisted state, regenerated on load and recomputed via refresh (see CORE.md).
+export class ComputedAbilityScore extends Composite implements AbilityScore {
   scores: Record<Ability, number> = enumMap(Abilities, (_) => 0);
 
   constructor() {

--- a/packages/core/src/stats/Stats.ts
+++ b/packages/core/src/stats/Stats.ts
@@ -1,5 +1,5 @@
 import { Holder } from "../composite/Aspects";
-import { Aspect, AspectKey, Composite } from "../composite/Composite";
+import { AspectKey, Composite } from "../composite/Composite";
 import { enumMap } from "../util/Types";
 import { type Ability } from "./AbilityScore";
 
@@ -55,8 +55,16 @@ export const AbilitySkills: Record<Ability, Skill[]> = {
   charisma: ["deception", "intimidation", "performance", "persuasion"],
 };
 
-@Aspect("SkillScore")
-export class SkillScore extends Composite {
+export interface SkillScore {
+  scores: Record<Skill, number>;
+  refresh(sheet: Composite): void;
+}
+
+export const SkillScore = new AspectKey<SkillScore>("SkillScore");
+
+// Computed projection over the sheet's SkillContributors. Transient: holds no persisted
+// state, regenerated on load and recomputed via refresh (see CORE.md).
+export class ComputedSkillScore extends Composite implements SkillScore {
   scores: Record<Skill, number> = enumMap(Skills, (_) => 0);
 
   refresh(sheet: Composite): void {

--- a/packages/core/src/stats/Stats.ts
+++ b/packages/core/src/stats/Stats.ts
@@ -1,5 +1,5 @@
 import { Holder } from "../composite/Aspects";
-import { AspectKey, Composite } from "../composite/Composite";
+import { Aspect, AspectKey, Composite } from "../composite/Composite";
 import { enumMap } from "../util/Types";
 import { type Ability } from "./AbilityScore";
 
@@ -55,16 +55,10 @@ export const AbilitySkills: Record<Ability, Skill[]> = {
   charisma: ["deception", "intimidation", "performance", "persuasion"],
 };
 
-export interface SkillScore {
-  scores: Record<Skill, number>;
-  refresh(sheet: Composite): void;
-}
-
-export const SkillScore = new AspectKey<SkillScore>("SkillScore");
-
-// Computed projection over the sheet's SkillContributors. Transient: holds no persisted
-// state, regenerated on load and recomputed via refresh (see CORE.md).
-export class ComputedSkillScore extends Composite implements SkillScore {
+// Computed projection over the sheet's SkillContributors. Transient: it declares no
+// @Property fields, so it is never serialized and is rebuilt on load (see CORE.md).
+@Aspect("SkillScore")
+export class SkillScore extends Composite {
   scores: Record<Skill, number> = enumMap(Skills, (_) => 0);
 
   refresh(sheet: Composite): void {

--- a/packages/core/src/stats/Stats.ts
+++ b/packages/core/src/stats/Stats.ts
@@ -1,3 +1,6 @@
+import { Holder } from "../composite/Aspects";
+import { Aspect, AspectKey, Composite } from "../composite/Composite";
+import { enumMap } from "../util/Types";
 import { type Ability } from "./AbilityScore";
 
 export const Skills = [
@@ -51,3 +54,23 @@ export const AbilitySkills: Record<Ability, Skill[]> = {
   wisdom: ["animal_handling", "insight", "medicine", "perception", "survival"],
   charisma: ["deception", "intimidation", "performance", "persuasion"],
 };
+
+@Aspect("SkillScore")
+export class SkillScore extends Composite {
+  scores: Record<Skill, number> = enumMap(Skills, (_) => 0);
+
+  refresh(sheet: Composite): void {
+    for (const child of sheet.get(Holder).children(sheet)) {
+      if (child.has(SkillContributor)) {
+        child.get(SkillContributor).apply(this);
+      }
+    }
+  }
+}
+
+export interface SkillContributor {
+  readonly source: Composite;
+  apply(skill: SkillScore): void;
+}
+
+export const SkillContributor = new AspectKey<SkillContributor>("SkillContributor");

--- a/packages/core/src/util/Util.ts
+++ b/packages/core/src/util/Util.ts
@@ -7,3 +7,14 @@ export function getMethodLabels(obj: object): string[] {
   }
   return [...labels].filter((label) => typeof Reflect.get(obj, label) === "function");
 }
+
+// A value carries no content when it is undefined or an empty plain object.
+export function isEmpty(value: unknown): boolean {
+  return (
+    value === undefined ||
+    (typeof value === "object" &&
+      value !== null &&
+      value.constructor === Object &&
+      Object.keys(value).length === 0)
+  );
+}

--- a/packages/playground/src/Main.ts
+++ b/packages/playground/src/Main.ts
@@ -4,10 +4,9 @@ import { AbilityScore } from "@atelier/core/stats/AbilityScore";
 import { BaseAbilityScore, PointBuyAbilityScore } from "@atelier/core/stats/BaseAbilityScore";
 
 const sheet = new Sheet();
-const score = new AbilityScore();
 sheet.provide(BaseAbilityScore, new PointBuyAbilityScore());
-sheet.provide(AbilityScore, score);
 
+const score = sheet.get(AbilityScore);
 score.refresh(sheet);
 
 console.log(sheet.get(Id).value);


### PR DESCRIPTION
## Summary

Implements computed skill scores as a pure projection over ability modifiers, completing the stat contribution chain. Introduces proper transient aspect handling: aspects with no `@Property` fields now serialize to nothing and are automatically rebuilt on load, enforcing the purity law.

## Key Changes

- **SkillScore projection**: New `@Aspect`-decorated `SkillScore` class that computes skill bonuses by folding ability modifiers from the sheet's `AbilityScore`. Implements the chaining pattern where a computed stat (`AbilityScore`) itself becomes a contributor to another (`SkillScore`).

- **Transient aspect serialization**: Modified `Structure` deserialization to:
  - Omit aspects with no persisted fields (empty serialization) from the output
  - Automatically rebuild all factoried aspects absent from serialized data on load
  - This makes transient aspects (like computed `AbilityScore` and `SkillScore`) invisible to serialization while ensuring they're always present

- **Ability modifier utility**: Extracted `abilityModifier(score)` function implementing the 5e formula `(score - 10) / 2`.

- **AbilityScore as contributor**: `AbilityScore` now extends `Composite` and provides itself as a `SkillContributor`, allowing `SkillScore` to discover and apply ability modifiers to governed skills.

- **Sheet structure defaults**: Updated `Sheet` structure to auto-provide `AbilityScore` and `SkillScore` factories, so they're always present without manual setup.

- **Documentation updates**: Clarified `Aspect` vs `AspectKey` distinction, removed obsolete `Template/StructureAspect` section, documented the transient-by-default rule and on-demand refresh pattern (no automatic post-load recompute).

## Implementation Details

The transient aspect pattern is enforced by the `isEmpty()` utility: an aspect serializes to nothing when it declares no `@Property` fields. On deserialization, `Structure` rebuilds every factoried aspect not present in the persisted data, making transient aspects self-healing. This satisfies the purity law: transient aspects are pure functions of persisted state, recomputed on demand via explicit `refresh()` calls rather than automatic post-load passes.

Skill contribution chains work because `AbilityScore.refresh()` runs before `SkillScore.refresh()`, and the latter reads `this.scores` at evaluation time—the thunk-at-evaluation-time contract ensures it sees already-computed ability scores.

https://claude.ai/code/session_01XZXMxYoL7t3yamFus4ibq1